### PR TITLE
Adding Quotes around Environment Variables Ingested into PHP-FPM Config

### DIFF
--- a/container/root/etc/nginx/fastcgi_params
+++ b/container/root/etc/nginx/fastcgi_params
@@ -30,3 +30,6 @@ fastcgi_param   HTTPS                   $https;
 
 # PHP only, required if PHP was built with --enable-force-cgi-redirect
 fastcgi_param   REDIRECT_STATUS         200;
+
+# Permits passing otherwise disabled header fields to the client
+fastcgi_pass_header Authorization;

--- a/container/root/run.sh
+++ b/container/root/run.sh
@@ -16,7 +16,7 @@ else
   echo 'Importing environment variables (prefixed by CFG_)'
   for p in $VARS
   do
-    ENV='env['${p/=/] = }
+    ENV='env['${p/=/] = \"}\"
     echo $ENV >> $DEST_CONF
   done
 


### PR DESCRIPTION
@bryanlatten 

Certain characters ingested into the PHP FPM config without being quoted seem to be problematic (e.g., `(`, among other special characters that may be used in secure passwords, etc).  This PR aims to resolve that issue.
