### PR TITLE
Pipes: head-slapping unix pipe work

### DIFF
--- a/container/root/app/public/index.php
+++ b/container/root/app/public/index.php
@@ -1,4 +1,10 @@
 <?php
 
 // NOTE: this file+folder should be replaced by the child app
+$stdout = fopen( "php://stdout", 'w' );
+$stderr = fopen( "php://stderr", 'w' );
+
+fwrite( $stdout, 'Using STDOUT pipe for output' );
+fwrite( $stderr, 'Using STDERR pipe for output' );
+
 phpinfo();


### PR DESCRIPTION
Allow PHP-FPM to log to stdout and filters the noise that is unfortunately added by default
