### PR TITLE
Configurable FastCGI/Proxy Buffers for Debug Mode

### DIFF
--- a/container/root/run.d/03-debug.sh
+++ b/container/root/run.d/03-debug.sh
@@ -3,12 +3,33 @@
 if [[ $CFG_APP_DEBUG = 1 || $CFG_APP_DEBUG = '1' || $CFG_APP_DEBUG = 'true' ]]
 then
 
+  FASTCGI_HEADER_SIZE=16k
+  FASTCGI_BUFFER_COUNT=4
+  FASTCGI_BUFFER_SIZE=16k
+
+  if [[ $FPM_HEADER_SIZE ]]
+  then
+    FASTCGI_HEADER_SIZE=$FPM_HEADER_SIZE
+  fi
+
+  if [[ $FPM_BUFFER_COUNT ]]
+  then
+    FASTCGI_BUFFER_COUNT=$FPM_BUFFER_COUNT
+  fi
+
+  if [[ $FPM_BUFFER_SIZE ]]
+  then
+    FASTCGI_BUFFER_SIZE=$FPM_BUFFER_SIZE
+  fi
+
   FASTCGI_PARAM_FILE=/etc/nginx/fastcgi_params
-  echo '[debug] increasing fastcgi buffer size for debug headers'
+  echo "[debug] increasing fastcgi buffer size for debug headers (headers: $FASTCGI_HEADER_SIZE; buffers: $FASTCGI_BUFFER_COUNT x $FASTCGI_BUFFER_SIZE)"
   echo "" >> $FASTCGI_PARAM_FILE
   echo "# Debug Buffer Sizes" >> $FASTCGI_PARAM_FILE
-  echo "fastcgi_buffer_size 16k;" >> $FASTCGI_PARAM_FILE
-  echo "fastcgi_buffers 4 16k;" >> $FASTCGI_PARAM_FILE
+  echo "fastcgi_buffer_size $FASTCGI_HEADER_SIZE;" >> $FASTCGI_PARAM_FILE
+  echo "fastcgi_buffers $FASTCGI_BUFFER_COUNT $FASTCGI_BUFFER_SIZE;" >> $FASTCGI_PARAM_FILE
+  echo "proxy_buffer_size $FASTCGI_HEADER_SIZE;" >> $FASTCGI_PARAM_FILE
+  echo "proxy_buffers $FASTCGI_BUFFER_COUNT $FASTCGI_BUFFER_SIZE;" >> $FASTCGI_PARAM_FILE
 
   echo '[debug] opcache disabled'
   php5dismod opcache


### PR DESCRIPTION
Both sets of buffer settings (`fastcgi_*` and `proxy_*`) are required to marshall all buffers through from FPM, to Nginx, and out to the downstream.  Fortunately, they can all be placed in the same configuration directive.
