### PR TITLE
add php5-dbg for debug symbols

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && \
     apt-get -yq install \
         php5=5.6.13+dfsg-1+deb.sury.org~trusty+3 \
         php5-fpm=5.6.13+dfsg-1+deb.sury.org~trusty+3 \
+        php5-dbg=5.6.13+dfsg-1+deb.sury.org~trusty+3 \
         php5-gearman=1.1.2-1+deb.sury.org~trusty+2 \
         php5-memcache=3.0.8-5+deb.sury.org~trusty+1 \
         php5-memcached=2.2.0-2+deb.sury.org~trusty+1 \


### PR DESCRIPTION
Adding php5-dbg package to allow gdb'ing generated coredumps.