### PR TITLE
Client max body: needs to be there to be replaced

### DIFF
--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -9,6 +9,9 @@ server {
   server_name web; # TODO: replace with environment variable
   root /app/public;
 
+  # Replace with env variable SERVER_MAX_BODY_SIZE
+  client_max_body_size 1m;
+
   index  index.html index.php;
 
   location / {


### PR DESCRIPTION
nginx `run.d` script attempts to replace something that isn't there, since this child overwrites the sites-available/default file
