### PR TITLE
Dockerfile: using upstream and non-privileged ports

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:4.1
+FROM behance/docker-nginx:5.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.
@@ -7,6 +7,7 @@ ENV CONF_PHPFPM=/etc/php5/fpm/php-fpm.conf \
     CONF_PHPMODS=/etc/php5/mods-available \
     CONF_FPMPOOL=/etc/php5/fpm/pool.d/www.conf \
     CONF_FPMOVERRIDES=/etc/php5/fpm/conf.d/overrides.user.ini \
+    SERVER_PORT=8080 \
     APP_ROOT=/app
 
 # Ensure the latest base packages are up to date (don't require a parent rebuild)

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,6 @@ ENV CONF_PHPFPM=/etc/php5/fpm/php-fpm.conf \
     CONF_PHPMODS=/etc/php5/mods-available \
     CONF_FPMPOOL=/etc/php5/fpm/pool.d/www.conf \
     CONF_FPMOVERRIDES=/etc/php5/fpm/conf.d/overrides.user.ini \
-    SERVER_PORT=8080 \
     APP_ROOT=/app
 
 # Ensure the latest base packages are up to date (don't require a parent rebuild)
@@ -102,4 +101,6 @@ RUN sed -i "s/listen = .*/listen = 127.0.0.1:9000/" $CONF_FPMPOOL && \
 COPY ./container/root /
 
 # Override default ini values for both CLI + FPM
-RUN php5enmod overrides
+RUN php5enmod overrides && \
+    # Set nginx to listen on defined port \
+    sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE

--- a/README.md
+++ b/README.md
@@ -51,6 +51,10 @@ Applications that leverage `bryanlatten/docker-php` as their container parent ar
 Inside the copied directory, there must be a directory named `public` -- this will be automatically assigned as the webroot for the web server, which expects
 a front controller called `index.php`.
 
+
+NOTE: Nginx is exposed and bound to an unprivileged port, `8080`
+
+
 ###Downstream Configuration
 ---
 Several environment variables can be used to configure various PHP FPM paramaters, as well as a few Nginx configurations.

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -3,7 +3,7 @@
 # @see https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/
 
 server {
-  listen 80;
+  listen 8080;
 
   server_tokens off; # Doesn't broadcast version level of server software
   server_name web; # TODO: replace with environment variable

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -3,7 +3,7 @@
 # @see https://nealpoole.com/blog/2011/04/setting-up-php-fastcgi-and-nginx-dont-trust-the-tutorials-check-your-configuration/
 
 server {
-  listen 8080;
+  listen 80;
 
   server_tokens off; # Doesn't broadcast version level of server software
   server_name web; # TODO: replace with environment variable

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 web:
   build: .
   ports:
-   - '8080:80'
+   - '8080:8080'
   environment:
     CFG_APP_DEBUG: 1
     SERVER_LOG_MINIMAL: 1


### PR DESCRIPTION
BREAKING: no longer uses port 80 inside the container, a privileged port
