### PR TITLE
FPM/Nginx: allowing locally-accessed fpm status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -122,7 +122,9 @@ RUN phpenmod overrides && \
     sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
     # Enable NewRelic via Ubuntu symlinks, but disable via extension command in file. Allows cross-variant startup scripts to function.
     phpenmod newrelic && \
-    sed -i 's/extension\s\?=/;extension =/' $CONF_PHPMODS/newrelic.ini
+    sed -i 's/extension\s\?=/;extension =/' $CONF_PHPMODS/newrelic.ini && \
+    # Enable status page at "/__status"
+    sed -i 's/;pm.status_path = .*/pm.status_path = \/__status/' $CONF_FPMPOOL
 
 RUN goss -g /tests/php-fpm/ubuntu.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -142,7 +142,9 @@ COPY ./container/root /
 
 # Make additional hacks to migrate files from Ubuntu to Alpine folder structure
 RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
-    rm $CONF_PHPMODS/00_opcache.ini
+    rm $CONF_PHPMODS/00_opcache.ini && \
+    # Enable status page at "/__status"
+    sed -i 's/;pm.status_path = .*/pm.status_path = \/__status/' $CONF_FPMPOOL
 
 RUN goss -g /tests/php-fpm/alpine.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -130,7 +130,9 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
     # Enable NewRelic via Ubuntu symlinks, but disable in file. Cross-variant startup script uncomments with env vars.
     phpenmod newrelic && \
-    sed -i 's/extension\s\?=/;extension =/' $CONF_PHPMODS/newrelic.ini
+    sed -i 's/extension\s\?=/;extension =/' $CONF_PHPMODS/newrelic.ini && \
+    # Enable status page at "/__status"
+    sed -i 's/;pm.status_path = .*/pm.status_path = \/__status/' $CONF_FPMPOOL
 
 RUN goss -g /tests/php-fpm/beta.goss.yaml validate && \
     /aufs_hack.sh

--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -44,6 +44,15 @@ server {
     fastcgi_pass 127.0.0.1:9000;
   }
 
+  # Allow locally-accessible (only) FPM status page
+  location ~ ^/__status$ {
+    access_log off;
+    allow 127.0.0.1;
+    deny all;
+    include fastcgi_params;
+    fastcgi_pass 127.0.0.1:9000;
+  }
+
   # Protect against accessing hidden files
   location ~ /\. {
     access_log off;


### PR DESCRIPTION
- Added at `/__status` to not conflict with any application routes
- Can be curl'd from an application healthcheck endpoint

![screen shot 2016-10-07 at 11 20 19 am](https://cloud.githubusercontent.com/assets/1202354/19195601/49bd483e-8c80-11e6-8860-f335b9d472d3.png)
