### PR TITLE
Dockerfile: added legacy 5.6 variant

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ before_install:
 script:
 - docker-compose build ubuntu
 - docker-compose build edge
-- docker-compose build alpine
+- docker-compose build legacy

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -49,25 +49,26 @@ RUN apt-get update -q && \
 RUN apt-get update -q && \
     apt-get -yqq install \
         php7.1 \
-        php7.1-fpm \
-        php7.1-mysql \
-        php7.1-xml \
+        php7.1-apcu \
+        php7.1-bz2 \
         php7.1-curl \
+        php7.1-fpm \
         php7.1-gd \
+        php7.1-igbinary \
         php7.1-intl \
         php7.1-json \
         php7.1-mbstring \
         php7.1-mcrypt \
+        php7.1-mysql \
         php7.1-pgsql \
+        php7.1-gearman \
+        php7.1-memcache \
+        php7.1-memcached \
+        php7.1-xml \
+        php7.1-yaml \
         php7.1-zip \
-        php-apcu \
-        php-gearman \
-        php-igbinary \
-        php-memcache \
-        php-memcached \
         php-redis \
         php-xdebug \
-        php-yaml \
         newrelic-php5=${NEWRELIC_VERSION} \
     && \
     phpdismod pdo_pgsql && \

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -2,10 +2,10 @@ FROM behance/docker-nginx:6.1
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.
-ENV CONF_PHPFPM=/etc/php/7.0/fpm/php-fpm.conf \
-    CONF_PHPMODS=/etc/php/7.0/mods-available \
-    CONF_FPMPOOL=/etc/php/7.0/fpm/pool.d/www.conf \
-    CONF_FPMOVERRIDES=/etc/php/7.0/fpm/conf.d/overrides.user.ini \
+ENV CONF_PHPFPM=/etc/php/5.6/fpm/php-fpm.conf \
+    CONF_PHPMODS=/etc/php/5.6/mods-available \
+    CONF_FPMPOOL=/etc/php/5.6/fpm/pool.d/www.conf \
+    CONF_FPMOVERRIDES=/etc/php/5.6/fpm/conf.d/overrides.user.ini \
     APP_ROOT=/app \
     PHP_FPM_MAX_CHILDREN=4096 \
     PHP_FPM_START_SERVERS=20 \
@@ -48,27 +48,27 @@ RUN apt-get update -q && \
 # Add PHP and support packages \
 RUN apt-get update -q && \
     apt-get -yqq install \
-        php7.0 \
-        php7.0-apcu \
-        php7.0-bz2 \
-        php7.0-curl \
-        php7.0-fpm \
-        php7.0-gd \
-        php7.0-gearman \
-        php7.0-igbinary \
-        php7.0-intl \
-        php7.0-json \
-        php7.0-mbstring \
-        php7.0-mcrypt \
-        php7.0-pgsql \
-        php7.0-memcache \
-        php7.0-memcached \
-        php7.0-mysql \
-        php7.0-redis \
-        php7.0-xdebug \
-        php7.0-xml \
-        php7.0-yaml \
-        php7.0-zip \
+        php5.6 \
+        php5.6-apcu \
+        php5.6-bz2 \
+        php5.6-curl \
+        php5.6-fpm \
+        php5.6-gd \
+        php5.6-igbinary \
+        php5.6-intl \
+        php5.6-json \
+        php5.6-mbstring \
+        php5.6-mcrypt \
+        php5.6-mysql \
+        php5.6-pgsql \
+        php5.6-gearman \
+        php5.6-memcache \
+        php5.6-memcached \
+        php5.6-redis \
+        php5.6-xdebug \
+        php5.6-xml \
+        php5.6-yaml \
+        php5.6-zip \
         newrelic-php5=${NEWRELIC_VERSION} \
         newrelic-php5-common=${NEWRELIC_VERSION} \
         newrelic-daemon=${NEWRELIC_VERSION} \
@@ -82,6 +82,13 @@ RUN apt-get update -q && \
     mv composer.phar /usr/local/bin/composer && \
     /clean.sh
 
+# Temporary Hack: unsupported PHP extensions are dumping old PHP pre-reqs into the mix
+# Even marking them to never install doesn't work. Removing for now, until all extensions are supported
+RUN apt-get remove --purge -yq \
+        php5.5 \
+        php7.0 \
+        php7.1
+
 # - Configure php-fpm to use TCP rather than unix socket (for stability), fastcgi_pass is also set by /etc/nginx/sites-available/default
 # - Set base directory for all php (/app), difficult to use APP_PATH as a replacement, otherwise / breaks command
 # - Baseline "optimizations" before benchmarking succeeded at concurrency of 150
@@ -91,8 +98,6 @@ RUN apt-get update -q && \
 # - Disable systemd integration, it is not present nor responsible for running service
 # - Enforce ACL that only 127.0.0.1 may connect
 # - Allow FPM to pick up extra configuration in fpm/conf.d folder
-
-# TODO: allow ENV specification of performance management at runtime (in run.d startup script)
 
 RUN sed -i "s/listen = .*/listen = 127.0.0.1:9000/" $CONF_FPMPOOL && \
     sed -i "s/;chdir = .*/chdir = \/app/" $CONF_FPMPOOL && \
@@ -124,16 +129,20 @@ RUN sed -i "s/listen = .*/listen = 127.0.0.1:9000/" $CONF_FPMPOOL && \
 # Overlay the root filesystem from this repo
 COPY ./container/root /
 
-# Override default ini values for both CLI + FPM
-RUN phpenmod overrides && \
+# Make additional hacks to migrate files/config from 7.0 --> 5.6 folder
+RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
+    cp /etc/php/7.0/fpm/conf.d/overrides.user.ini $CONF_FPMOVERRIDES && \
+    # Hack: share startup scripts with php 7.0 version by symlinking \
+    ln -s /usr/sbin/php-fpm5.6 /usr/sbin/php-fpm7.0 && \
+    # Override default ini values for both CLI + FPM \
+    phpenmod overrides && \
     # Set nginx to listen on defined port \
     sed -i "s/listen [0-9]*;/listen ${CONTAINER_PORT};/" $CONF_NGINX_SITE && \
-    # Enable NewRelic via Ubuntu symlinks, but disable via extension command in file. Allows cross-variant startup scripts to function.
+    # Enable NewRelic via Ubuntu symlinks, but disable in file. Cross-variant startup script uncomments with env vars.
     phpenmod newrelic && \
     sed -i 's/extension\s\?=/;extension =/' $CONF_PHPMODS/newrelic.ini && \
     # Enable status page at "/__status"
     sed -i 's/;pm.status_path = .*/pm.status_path = \/__status/' $CONF_FPMPOOL
 
-RUN goss -g /tests/php-fpm/ubuntu.goss.yaml validate && \
+RUN goss -g /tests/php-fpm/legacy.goss.yaml validate && \
     /aufs_hack.sh
-

--- a/README.md
+++ b/README.md
@@ -10,34 +10,37 @@ Three variants are available:
 - (default) Ubuntu-based, PHP 7.0  
 - (slim) Alpine-based, PHP 7.0, tagged as `-alpine`  
 - (beta) Ubuntu-based, PHP 7.1, tagged as `-beta`  
+- (legacy) Ubuntu-based, PHP 5.6, tagged as `-legacy`  
 
 ###Includes
 ---
 - Nginx
-- PHP/PHP-FPM (7.0)
+- PHP/PHP-FPM (7.0, 7.1, 5.6)
 - Extra PHP Modules:
 
-`*` - not available on Alpine variant  
-`**` - backwards compatible library not available on Alpine variant  
-`^` - not available on beta tag  
-`~` - disabled by default (use `phpenmod` to enable on Ubuntu-based variants, uncomment .ini file otherwise)
-  - apcu**^
-  - bz2^
+`*`  - not available on Alpine variant  
+`^`  - not available on Beta tag  
+`~`  - disabled by default (use `phpenmod` to enable on Ubuntu-based variants, uncomment .ini file otherwise)
+  - apc*^ (only visible for backwards compatibility) 
+  - apcu^
+  - calendar
+  - bz2
   - ctype
   - curl
+  - date
   - dom
   - exif
   - fpm
   - gd
   - gearman*
   - iconv
-  - igbinary*^
+  - igbinary*
   - intl
   - json
   - mbstring
   - mcrypt
   - memcache*^
-  - memcached*^
+  - memcached*
   - mysqli
   - mysqlnd
   - newrelic~ (activates with env variables)
@@ -61,7 +64,7 @@ Three variants are available:
   - xml
   - xmlreader
   - xmlwriter
-  - yaml*~ 
+  - yaml*~
   - zip
   - zlib
 
@@ -97,7 +100,7 @@ Variable | Example | Description
 `PHP_FPM_MAX_CHILDREN` | `PHP_FPM_MAX_CHILDREN=15` | [docs](http://php.net/manual/en/install.fpm.configuration.php)
 `PHP_FPM_START_SERVERS` | `PHP_FPM_START_SERVERS=128` | [docs](http://php.net/manual/en/install.fpm.configuration.php)
 `PHP_FPM_MAX_REQUESTS` | `PHP_FPM_MAX_REQUESTS=1000` | [docs](http://php.net/manual/en/install.fpm.configuration.php) How many requests an individual FPM worker will process before recycling
-`PHP_FPM_MIN_SPARE_SERVERS` | `PHP_FPM_MIN_SPARE_SERVERS=5` | [docs](http://php.net/manual/en/install.fpm.configuration.php) 
+`PHP_FPM_MIN_SPARE_SERVERS` | `PHP_FPM_MIN_SPARE_SERVERS=5` | [docs](http://php.net/manual/en/install.fpm.configuration.php)
 `PHP_FPM_MAX_SPARE_SERVERS` | `PHP_FPM_MAX_SPARE_SERVERS=100` | [docs](http://php.net/manual/en/install.fpm.configuration.php)
 
 

--- a/container/root/tests/php-fpm/legacy.goss.yaml
+++ b/container/root/tests/php-fpm/legacy.goss.yaml
@@ -1,0 +1,55 @@
+# Note: base cannot be used because versions are different
+# gossfile:
+#   base.goss.yaml: {}
+group:
+  www-data:
+    exists: true
+command:
+  php -m:
+    exit-status: 0
+    stderr: ['!/./']
+  php -v:
+    exit-status: 0
+    stderr: ['!/./']
+  php-fpm7.0 -m:
+    exit-status: 0
+    stderr: ['!/./']
+  php-fpm7.0 -v:
+    exit-status: 0
+    stderr: ['!/./']
+  php -r 'echo PHP_MAJOR_VERSION;':
+    exit-status: 0
+    stdout: [5]
+    stderr: ['!/./']
+  php -r 'echo PHP_MINOR_VERSION;':
+    exit-status: 0
+    stdout: [6]
+    stderr: ['!/./']
+
+package:
+  php5.6:
+    installed: true
+  php5.6-cli:
+    installed: true
+  php5.6-curl:
+    installed: true
+  php5.6-fpm:
+    installed: true
+  php5.6-gd:
+    installed: true
+  php5.6-intl:
+    installed: true
+  php5.6-json:
+    installed: true
+  php5.6-mbstring:
+    installed: true
+  php5.6-mysql:
+    installed: true
+  php5.6-opcache:
+    installed: true
+  php5.6-xml:
+    installed: true
+  php5.6-zip:
+    installed: true
+  php-yaml:
+    installed: true

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,3 +59,23 @@ edge:
    - ./container/root/app:/app
    - ./container/root/tests/php-fpm/base.goss.yaml:/tests/php-fpm/base.goss.yaml
    - ./container/root/tests/php-fpm/beta.goss.yaml:/tests/php-fpm/beta.goss.yaml
+legacy:
+  build: .
+  dockerfile: Dockerfile-legacy
+  ports:
+   - '8083:8080'
+  environment:
+    CFG_APP_DEBUG: 1
+    SERVER_LOG_MINIMAL: 1
+    PHP_FPM_MEMORY_LIMIT: 257M
+    PHP_FPM_MAX_EXECUTION_TIME: 61
+    PHP_FPM_UPLOAD_MAX_FILESIZE: 100M
+    SERVER_APP_NAME: docker-test
+    REPLACE_NEWRELIC_APP: abcdefg
+    REPLACE_NEWRELIC_LICENSE: hijklmno
+    S6_KILL_FINISH_MAXTIME: 1
+    S6_KILL_GRACETIME: 1
+  volumes:
+   - ./container/root/app:/app
+   - ./container/root/tests/php-fpm/base.goss.yaml:/tests/php-fpm/base.goss.yaml
+   - ./container/root/tests/php-fpm/beta.goss.yaml:/tests/php-fpm/legacy.goss.yaml


### PR DESCRIPTION
- Alphabetized most mods installed
- Cleaned up README, now reflects upstream maintainer's 7.1 support status
- Made NewRelic components explicit, if/when we downgrade to an older version for stability
