### PR TITLE
Opcache: enabled by default with validated timestamps

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,8 @@ ENV CONF_PHPFPM=/etc/php/7.0/fpm/php-fpm.conf \
     PHP_FPM_MEMORY_LIMIT=256M \
     PHP_FPM_MAX_EXECUTION_TIME=60 \
     PHP_FPM_UPLOAD_MAX_FILESIZE=1M \
-    NEWRELIC_VERSION=6.7.0.174
+    NEWRELIC_VERSION=6.7.0.174 \
+    CFG_APP_DEBUG=1
 
 # Ensure cleanup script is available for the next command
 ADD ./container/root/clean.sh /clean.sh

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -15,7 +15,8 @@ ENV CONF_PHPFPM=/etc/php7/php-fpm.conf \
     PHP_FPM_MEMORY_LIMIT=256M \
     PHP_FPM_MAX_EXECUTION_TIME=60 \
     PHP_FPM_UPLOAD_MAX_FILESIZE=1M \
-    NEWRELIC_VERSION=6.7.0.174
+    NEWRELIC_VERSION=6.7.0.174 \
+    CFG_APP_DEBUG=1
 
 RUN echo '@edge http://dl-cdn.alpinelinux.org/alpine/edge/testing' >> /etc/apk/repositories && \
     echo '@community http://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories && \

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -15,7 +15,8 @@ ENV CONF_PHPFPM=/etc/php/7.1/fpm/php-fpm.conf \
     PHP_FPM_MEMORY_LIMIT=256M \
     PHP_FPM_MAX_EXECUTION_TIME=60 \
     PHP_FPM_UPLOAD_MAX_FILESIZE=1M \
-    NEWRELIC_VERSION=6.7.0.174
+    NEWRELIC_VERSION=6.7.0.174 \
+    CFG_APP_DEBUG=1
 
 # Ensure cleanup script is available for the next command
 ADD ./container/root/clean.sh /clean.sh

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -15,7 +15,8 @@ ENV CONF_PHPFPM=/etc/php/5.6/fpm/php-fpm.conf \
     PHP_FPM_MEMORY_LIMIT=256M \
     PHP_FPM_MAX_EXECUTION_TIME=60 \
     PHP_FPM_UPLOAD_MAX_FILESIZE=1M \
-    NEWRELIC_VERSION=6.7.0.174
+    NEWRELIC_VERSION=6.7.0.174 \
+    CFG_APP_DEBUG=1
 
 # Ensure cleanup script is available for the next command
 ADD ./container/root/clean.sh /clean.sh

--- a/container/root/etc/php/7.0/mods-available/opcache.ini
+++ b/container/root/etc/php/7.0/mods-available/opcache.ini
@@ -14,4 +14,4 @@ opcache.optimization_level=0xfffffff0
 opcache.interned_strings_buffer=16
 
 opcache.revalidate_freq=0
-opcache.validate_timestamps=0
+opcache.validate_timestamps=${CFG_APP_DEBUG}

--- a/container/root/run.d/07-newrelic.sh
+++ b/container/root/run.d/07-newrelic.sh
@@ -1,5 +1,6 @@
-#!/usr/bin/with-contenv bash
+#!/bin/bash
 
+# When both App ID and license are provided, automatically enable extension
 if [ $REPLACE_NEWRELIC_APP ] && [ $REPLACE_NEWRELIC_LICENSE ]
 then
   echo "[newrelic] enabling APM metrics for ${REPLACE_NEWRELIC_APP}"

--- a/container/root/run.d/08-php-opcache.sh
+++ b/container/root/run.d/08-php-opcache.sh
@@ -1,9 +1,8 @@
-#!/usr/bin/with-contenv bash
+#!/bin/bash
 
 if [[ $CFG_APP_DEBUG = 1 || $CFG_APP_DEBUG = '1' || $CFG_APP_DEBUG = 'true' ]]
 then
-  echo '[debug] opcache disabled, WATCHING file changes'
-  sed -i 's/zend_extension=/;zend_extension=/' $CONF_PHPMODS/opcache.ini
+  echo '[debug] Opcache WATCHING for file changes'
 else
   echo '[debug] Opcache set to PERFORMANCE, NOT WATCHING for file changes'
 fi


### PR DESCRIPTION
- Opcache: ensured extension is always enabled, but by default ensures file updates are visible to the end user
- Run.d: moved new relic and opcache (debug) scripts
  -  To account for non-S6 workloads like workers and crons, 
    move startup mechanisms to run.d instead of S6.
- Readme: quick updates, added defaults to configuration
