### PR TITLE
Yaml/Redis: moving to pecl-installed stable versions for PHP7

### DIFF
--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -48,11 +48,24 @@ RUN apt-get update -q && \
 
 # Add PHP and support packages \
 RUN apt-get update -q && \
+    # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
+    apt-mark hold \
+            php5.5-cli \
+            php5.5-json \
+            php5.5-common \
+            php5.6-cli \
+            php5.6-json \
+            php5.6-common \
+            php7.0-cli \
+            php7.0-common \
+            php7.0-json \
+    && \
     apt-get -yqq install \
         php7.1 \
         php7.1-apcu \
         php7.1-bz2 \
         php7.1-curl \
+        php7.1-dev \
         php7.1-fpm \
         php7.1-gd \
         php7.1-igbinary \
@@ -66,26 +79,30 @@ RUN apt-get update -q && \
         php7.1-memcache \
         php7.1-memcached \
         php7.1-xml \
-        php7.1-yaml \
         php7.1-zip \
-        php-redis \
-        php-xdebug \
+        # php-xdebug \  <-- no longer built for PHP 7.1
         newrelic-php5=${NEWRELIC_VERSION} \
+        newrelic-php5-common=${NEWRELIC_VERSION} \
+        newrelic-daemon=${NEWRELIC_VERSION} \
+        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
-    phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
+    # Install new PHP7-stable version of Yaml \
+    pecl install yaml-2.0.0 && \
+    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
+    # Install new PHP7-stable version of Redis \
+    pecl install redis-3.0.0 && \
+    echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
+    # Remove dev packages that were only in place just to compile extensions
+    apt-get remove -yqq \
+        php7.1-dev \
+    && \
     /clean.sh
-
-# Temporary Hack: unsupported PHP extensions are dumping old PHP pre-reqs into the mix
-# Even marking them to never install doesn't work. Removing for now, until all extensions are supported
-RUN apt-get remove --purge -yq \
-        php5.5 \
-        php7.0
 
 # - Configure php-fpm to use TCP rather than unix socket (for stability), fastcgi_pass is also set by /etc/nginx/sites-available/default
 # - Set base directory for all php (/app), difficult to use APP_PATH as a replacement, otherwise / breaks command

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -48,11 +48,23 @@ RUN apt-get update -q && \
 
 # Add PHP and support packages \
 RUN apt-get update -q && \
+    # Ensure PHP 5.5 + 7.0 + 7.1 don't accidentally get added by PPA
+    apt-mark hold \
+            php5.5-cli \
+            php5.5-common \
+            php5.5-json \
+            php7.0-cli \
+            php7.0-common \
+            php7.0-json \
+            php7.1-cli \
+            php7.1-common \
+    && \
     apt-get -yqq install \
         php5.6 \
         php5.6-apcu \
         php5.6-bz2 \
         php5.6-curl \
+        php5.6-dev \
         php5.6-fpm \
         php5.6-gd \
         php5.6-igbinary \
@@ -65,30 +77,31 @@ RUN apt-get update -q && \
         php5.6-gearman \
         php5.6-memcache \
         php5.6-memcached \
-        php5.6-redis \
         php5.6-xdebug \
         php5.6-xml \
-        php5.6-yaml \
         php5.6-zip \
         newrelic-php5=${NEWRELIC_VERSION} \
         newrelic-php5-common=${NEWRELIC_VERSION} \
         newrelic-daemon=${NEWRELIC_VERSION} \
+        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
-    phpdismod redis && \
-    phpdismod yaml && \
     phpdismod xdebug && \
     curl -sS https://getcomposer.org/installer | php && \
-    mv composer.phar /usr/local/bin/composer && \
-    /clean.sh
+    mv composer.phar /usr/local/bin/composer
 
-# Temporary Hack: unsupported PHP extensions are dumping old PHP pre-reqs into the mix
-# Even marking them to never install doesn't work. Removing for now, until all extensions are supported
-RUN apt-get remove --purge -yq \
-        php5.5 \
-        php7.0 \
-        php7.1
+    # Install new PHP5-stable version of Yaml \
+RUN pecl install yaml-1.3.0 && \
+    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
+    # Install new PHP5-stable version of Redis \
+    pecl install redis-2.2.8 && \
+    echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
+    # Remove dev packages that were only in place just to compile extensions
+    apt-get remove -yqq \
+        php5.6-dev \
+    && \
+    /clean.sh
 
 # - Configure php-fpm to use TCP rather than unix socket (for stability), fastcgi_pass is also set by /etc/nginx/sites-available/default
 # - Set base directory for all php (/app), difficult to use APP_PATH as a replacement, otherwise / breaks command

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Three variants are available:
   - sysvmsg
   - sysvsem
   - sysvshm
-  - xdebug~
+  - xdebug~^
   - xml
   - xmlreader
   - xmlwriter

--- a/container/root/tests/php-fpm/alpine.goss.yaml
+++ b/container/root/tests/php-fpm/alpine.goss.yaml
@@ -84,3 +84,23 @@ package:
     installed: true
   php7-zlib:
     installed: true
+
+command:
+  # Hack: enable and disable the various extensions to test their presence
+  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod redis && php -m | grep redis && phpdismod redis:
+    exit-status: 0
+    stderr: ['!/./']
+
+

--- a/container/root/tests/php-fpm/beta.goss.yaml
+++ b/container/root/tests/php-fpm/beta.goss.yaml
@@ -51,5 +51,21 @@ package:
     installed: true
   php7.1-zip:
     installed: true
-  php-yaml:
-    installed: true
+
+command:
+  # Hack: enable and disable the various extensions to test their presence
+  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod redis && php -m | grep redis && phpdismod redis:
+    exit-status: 0
+    stderr: ['!/./']

--- a/container/root/tests/php-fpm/legacy.goss.yaml
+++ b/container/root/tests/php-fpm/legacy.goss.yaml
@@ -51,8 +51,6 @@ package:
     installed: true
   php5.6-zip:
     installed: true
-  php-yaml:
-    installed: true
 
 file:
   /etc/php/5.6/mods-available/newrelic.ini:
@@ -60,4 +58,22 @@ file:
     contains:
       - "${REPLACE_NEWRELIC_APP}"
       - "${REPLACE_NEWRELIC_LICENSE}"
+
+command:
+  # Hack: enable and disable the various extensions to test their presence
+  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod redis && php -m | grep redis && phpdismod redis:
+    exit-status: 0
+    stderr: ['!/./']
 

--- a/container/root/tests/php-fpm/ubuntu.goss.yaml
+++ b/container/root/tests/php-fpm/ubuntu.goss.yaml
@@ -44,9 +44,24 @@ package:
     installed: true
   php-msgpack:
     installed: true
-  php-redis:
-    installed: true
-  php-yaml:
-    installed: true
   php-xdebug:
     installed: true
+
+command:
+  # Hack: enable and disable the various extensions to test their presence
+  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+
+  phpenmod redis && php -m | grep redis && phpdismod redis:
+    exit-status: 0
+    stderr: ['!/./']
+


### PR DESCRIPTION
- Swapped from PPA to PECL-maintained stable versions
- Added additional tests for default-disabled extensions
- Added `hold` for untargetted versions of PHP