### PR TITLE
Tests: now testing without side affects (!)

### DIFF
--- a/container/root/tests/php-fpm/alpine.goss.yaml
+++ b/container/root/tests/php-fpm/alpine.goss.yaml
@@ -19,23 +19,6 @@ command:
     stdout: [PHP 7.0]
     stderr: ['!/./']
 
-  # Hack: enable and disable the various extensions to test their presence
-  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod redis && php -m | grep redis && phpdismod redis:
-    exit-status: 0
-    stderr: ['!/./']
-
 package:
   php7:
     installed: true

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -24,3 +24,22 @@ command:
   php-fpm -v:
     exit-status: 0
     stderr: ['!/./']
+
+  # Hack: to test and validate by-default disabled extensions [without side effects]
+  # 1. run php with no ini file (-n)
+  # 2. pass ini key-value (-d), enable the single extension to test
+  # 3. list the newly loaded php mods (-m)
+  # 4. grep the output of the loaded mods for the one under test
+  php -n -d extension=yaml.so -m | grep yaml:
+    exit-status: 0
+    stderr: ['!/./']
+  php -n -d extension=pgsql.so -m | grep pgsql:
+    exit-status: 0
+    stderr: ['!/./']
+  # Note: pdo_pgsql requires pdo to also be present in order to be loaded properly
+  php -n -d extension=pdo.so -d extension=pdo_pgsql.so -m:
+    exit-status: 0
+    stderr: ['!/./']
+  php -n -d extension=redis.so -m | grep redis:
+    exit-status: 0
+    stderr: ['!/./']

--- a/container/root/tests/php-fpm/beta.goss.yaml
+++ b/container/root/tests/php-fpm/beta.goss.yaml
@@ -19,23 +19,6 @@ command:
     stdout: [PHP 7.1]
     stderr: ['!/./']
 
-  # Hack: enable and disable the various extensions to test their presence
-  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod redis && php -m | grep redis && phpdismod redis:
-    exit-status: 0
-    stderr: ['!/./']
-
 package:
   php7.1:
     installed: true

--- a/container/root/tests/php-fpm/legacy.goss.yaml
+++ b/container/root/tests/php-fpm/legacy.goss.yaml
@@ -19,23 +19,6 @@ command:
     stdout: [PHP 5.6]
     stderr: ['!/./']
 
-  # Hack: enable and disable the various extensions to test their presence
-  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-
-  phpenmod redis && php -m | grep redis && phpdismod redis:
-    exit-status: 0
-    stderr: ['!/./']
-
 package:
   php5.6:
     installed: true

--- a/container/root/tests/php-fpm/ubuntu.goss.yaml
+++ b/container/root/tests/php-fpm/ubuntu.goss.yaml
@@ -19,20 +19,6 @@ command:
     stdout: [PHP 7.0]
     stderr: ['!/./']
 
-  # Hack: enable and disable the various extensions to test their presence
-  phpenmod yaml && php -m | grep yaml && phpdismod yaml:
-    exit-status: 0
-    stderr: ['!/./']
-  phpenmod pgsql && php -m | grep pgsql && phpdismod pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-  phpenmod pdo_pgsql && php -m | grep pdo_pgsql && phpdismod pdo_pgsql:
-    exit-status: 0
-    stderr: ['!/./']
-  phpenmod redis && php -m | grep redis && phpdismod redis:
-    exit-status: 0
-    stderr: ['!/./']
-
 package:
   php7.0:
     installed: true


### PR DESCRIPTION
If tests are run outside build environment (from a client), the current test [hacks] to check the validity of by-default disabled extensions has side affects. Fixed.

Also promoted tests to be run agnostically in all variants. 