### PR TITLE
PHP: removed 5.5 from held packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -54,9 +54,6 @@ RUN /bin/bash -e /security_updates.sh && \
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
-            php5.5-cli \
-            php5.5-common \
-            php5.5-json \
             php5.6-cli \
             php5.6-common \
             php5.6-json \

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -54,9 +54,6 @@ RUN /bin/bash -e /security_updates.sh && \
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
-            php5.5-cli \
-            php5.5-json \
-            php5.5-common \
             php5.6-cli \
             php5.6-common \
             php5.6-json \

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -54,9 +54,6 @@ RUN /bin/bash -e /security_updates.sh && \
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 7.0 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
-            php5.5-cli \
-            php5.5-json \
-            php5.5-common \
             php7.0-cli \
             php7.0-common \
             php7.0-json \


### PR DESCRIPTION
These no longer exist in the repo, so attempting to hold them will fail.