### PR TITLE
Dockerfile: updated to parent’s 7.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,6 @@
 # SASS
 .sass-cache
 *.css.map
+
+# tmp file for upload
+tmp.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,12 @@ before_install:
   - chmod +x docker-compose
   - sudo mv docker-compose /usr/local/bin
 
+# - Build and run all variants
+# - Ensure text from phpinfo is present in default response
+# - Create a 98MB tmp file
+# - Upload file to each variant
+# - Ensure text from phpinfo is present in response to upload, which is returned for everything
+# ---- mainly to check /tmp permission issues from nginx
 script:
 - docker-compose build ubuntu
 - docker-compose build edge
@@ -24,4 +30,9 @@ script:
 - curl localhost:8081 | grep "PHP Version 7.0."
 - curl localhost:8082 | grep "PHP Version 7.1."
 - curl localhost:8083 | grep "PHP Version 5.6."
+- dd if=/dev/zero of=tmp.txt count=100000 bs=1024
+- curl --form upload=@tmp.txt localhost:8080 | grep "PHP Version 7.0."
+- curl --form upload=@tmp.txt localhost:8081 | grep "PHP Version 7.0."
+- curl --form upload=@tmp.txt localhost:8082 | grep "PHP Version 7.1."
+- curl --form upload=@tmp.txt localhost:8083 | grep "PHP Version 5.6."
 - docker-compose kill

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:6.4
+FROM behance/docker-nginx:7.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:6.4-alpine
+FROM behance/docker-nginx:7.0-alpine
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:6.4
+FROM behance/docker-nginx:7.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:6.4
+FROM behance/docker-nginx:7.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.


### PR DESCRIPTION
- Using parent's 7.0 branch: https://github.com/behance/docker-nginx/releases/tag/7.0.0, which switches to `nginx-light` instead of `nginx-full`
