### PR TITLE
Dockerfile(s): updated parent on non-main variants

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,20 +19,4 @@ before_install:
 # - Ensure text from phpinfo is present in response to upload, which is returned for everything
 # ---- mainly to check /tmp permission issues from nginx
 script:
-- docker-compose build ubuntu
-- docker-compose build edge
-- docker-compose build legacy
-- docker-compose build alpine
-- docker-compose up -d
-- sleep 5
-- docker-compose ps
-- curl localhost:8080 | grep "PHP Version 7.0."
-- curl localhost:8081 | grep "PHP Version 7.0."
-- curl localhost:8082 | grep "PHP Version 7.1."
-- curl localhost:8083 | grep "PHP Version 5.6."
-- dd if=/dev/zero of=tmp.txt count=100000 bs=1024
-- curl --form upload=@tmp.txt localhost:8080 | grep "PHP Version 7.0."
-- curl --form upload=@tmp.txt localhost:8081 | grep "PHP Version 7.0."
-- curl --form upload=@tmp.txt localhost:8082 | grep "PHP Version 7.1."
-- curl --form upload=@tmp.txt localhost:8083 | grep "PHP Version 5.6."
-- docker-compose kill
+- bash ./test.sh localhost

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:7.0-alpine
+FROM behance/docker-nginx:8.0-alpine
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:7.0
+FROM behance/docker-nginx:8.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:7.0
+FROM behance/docker-nginx:8.0
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ Production Mode: an immutable container (without file updates) should set `CFG_A
 
 NOTE: Nginx is exposed and bound to an unprivileged port, `8080`  
 
-####Monitoring
+###Monitoring
 --- 
 1. NewRelic APM: automatically enabled by adding providing environment variables `REPLACE_NEWRELIC_APP` and `REPLACE_NEWRELIC_LICENSE`
 1. PHP-FPM Status: available *only* inside container at `/__status`. Application healthcheck can pull PHP-FPM statistics from `http://127.0.0.1/__status?json`. To open to more clients than local, add more `allow` statements in `__status` location block in `$CONF_NGINX_SITE`(`/etc/nginx/sites-available/default`)
@@ -121,3 +121,10 @@ Variable | Example | Default | Description
 `PHP_OPCACHE_MEMORY_CONSUMPTION` | `PHP_OPCACHE_MEMORY_CONSUMPTION=512` | 128 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.memory-consumption)
 `PHP_OPCACHE_MAX_WASTED_PERCENTAGE` | `PHP_OPCACHE_MAX_WASTED_PERCENTAGE=10` | 5 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.max-wasted-percentage)
 `PHP_OPCACHE_INTERNED_STRINGS_BUFFER` | `PHP_OPCACHE_INTERNED_STRINGS_BUFFER=64` | 16 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.interned-strings-buffer)
+
+###Testing
+---   
+- Requires `docker` and `docker-compose`   
+To test locally, run `bash -e ./test.sh {docker-machine}` where `docker-machine` is the IP of the connected docker engine. 
+These same tests get run automatically, per pull request, via Travis CI
+

--- a/test.sh
+++ b/test.sh
@@ -1,0 +1,38 @@
+#!/bin/bash -e
+
+set -o pipefail
+
+#-----------------------------------------------------------------------
+# Performs a simple integration test
+#
+# - Build each variant
+# - Assert major, minor language versions from default phpinfon page
+# - Create 98MB file for upload (compose sets upload limit to 100MB)
+# - TODO: create goss tests command probe while containers are up
+#-----------------------------------------------------------------------
+
+MACHINE=$1
+
+if [ -z "$1" ]
+then
+  printf "Basic integration script for docker-php and its variants.\n\nUsage:\n\ttest.sh [docker-machine ip]\n"
+  exit 1;
+fi
+
+docker-compose build ubuntu
+docker-compose build edge
+docker-compose build legacy
+docker-compose build alpine
+docker-compose up -d
+sleep 5
+docker-compose ps
+
+curl $MACHINE:8080 | grep "PHP Version 7.0."
+curl $MACHINE:8081 | grep "PHP Version 7.0."
+curl $MACHINE:8082 | grep "PHP Version 7.1."
+curl $MACHINE:8083 | grep "PHP Version 5.6."
+dd if=/dev/zero of=tmp.txt count=100000 bs=1024
+curl --form upload=@tmp.txt $MACHINE:8080 | grep "PHP Version 7.0." > /dev/null
+curl --form upload=@tmp.txt $MACHINE:8081 | grep "PHP Version 7.0." > /dev/null
+curl --form upload=@tmp.txt $MACHINE:8082 | grep "PHP Version 7.1." > /dev/null
+curl --form upload=@tmp.txt $MACHINE:8083 | grep "PHP Version 5.6." > /dev/null


### PR DESCRIPTION
Also took the opportunity to break travis-specific tests into a generic bash script. Since docker instance's location is different between a local install and travis' installation, the script accepts the location as an argument.