### PR TITLE
Dockerfile-edge: 7.1 variant out of beta

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -98,7 +98,7 @@ RUN apt-get update -q && \
     pecl install yaml-2.0.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP7-stable version of Redis \
-    pecl install redis-3.1.0 && \
+    pecl install redis-3.1.1 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Install kafka extension
     pecl install rdkafka-3.0.1 && \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -32,6 +32,7 @@ RUN apk update && \
       curl \
       wget \
       php7 \
+      php7-bz2 \
       php7-fpm \
       php7-apcu \
       php7-calendar \
@@ -61,7 +62,6 @@ RUN apk update && \
       php7-pdo_mysql \
       php7-phar \
       php7-posix \
-      # php7-readline \  --- not currently working on PHP 7
       php7-session \
       php7-sockets \
       php7-sysvmsg \
@@ -121,11 +121,14 @@ RUN apk update && \
         autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     && \
     sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) && \
+    # Install new PHP7-stable version of igbinary \
+    pecl install igbinary-2.0.1 && \
+    echo "extension=igbinary.so" > $CONF_PHPMODS/igbinary.ini && \
     # Install new PHP7-stable version of Yaml \
     pecl install yaml-2.0.0 && \
     echo ";extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP7-stable version of Redis \
-    pecl install redis-3.1.0 && \
+    pecl install redis-3.1.1 && \
     echo ";extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Install kafka extension
     pecl install rdkafka && \

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -77,12 +77,12 @@ RUN apt-get update -q && \
         php7.1-mcrypt \
         php7.1-mysql \
         php7.1-pgsql \
-        # php7.1-gearman \  <-- no longer built for PHP 7.1
+        php7.1-gearman \
         php7.1-memcache \
         php7.1-memcached \
         php7.1-xml \
         php7.1-zip \
-        # php-xdebug \  <-- no longer built for PHP 7.1
+        php-xdebug \
         newrelic-php5=${NEWRELIC_VERSION} \
         newrelic-php5-common=${NEWRELIC_VERSION} \
         newrelic-daemon=${NEWRELIC_VERSION} \
@@ -91,14 +91,15 @@ RUN apt-get update -q && \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
+    phpdismod xdebug && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
-    # Install new PHP7-stable version of Yaml \
+    # Install new PHP 7.1-stable version of Yaml \
     pecl install yaml-2.0.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
-    # Install new PHP7-stable version of Redis <--- currently broken due to PHP 7.1.0-1 compatibility with version check
-    # pecl install redis-3.1.0 && \
-    # echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
+    # Install new PHP 7.1-stable version of Redis
+    pecl install redis-3.1.1 && \
+    echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Install kafka extension
     pecl install rdkafka-3.0.1 && \
     echo "extension=rdkafka.so" > $CONF_PHPMODS/rdkafka.ini && \
@@ -123,5 +124,5 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     # - Run standard set of tweaks to ensure runs performant, reliably, and consistent between variants
     /bin/bash -e /prep-php.sh
 
-RUN goss -g /tests/php-fpm/beta.goss.yaml validate && \
+RUN goss -g /tests/php-fpm/edge.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -98,7 +98,7 @@ RUN apt-get update -q && \
     pecl install yaml-1.3.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP5-stable version of Redis \
-    pecl install redis-3.1.0 && \
+    pecl install redis-3.1.1 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
      # Install kafka extension
     pecl install rdkafka-3.0.1 && \

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
 Three variants are available:
 - (default) Ubuntu-based, PHP 7.0  
 - (slim) Alpine-based, PHP 7.0, tagged as `-alpine`  
-- (beta) Ubuntu-based, PHP 7.1, tagged as `-beta`  
+- (edge) Ubuntu-based, PHP 7.1, tagged as `-edge`  
 - (legacy) Ubuntu-based, PHP 5.6, tagged as `-legacy`  
 
 ###Includes
@@ -23,10 +23,10 @@ Three variants are available:
 - Extra PHP Modules:
 
 `*`  - not available on Alpine variant  
-`^`  - not available on Beta tag  
+`^`  - not available on Edge variant  
 `~`  - disabled by default (use `phpenmod` to enable on Ubuntu-based variants, uncomment .ini file otherwise)
-  - apc*^ (only visible for backwards compatibility) 
-  - apcu^
+  - apc* (only visible for backwards compatibility) 
+  - apcu
   - calendar
   - bz2
   - ctype
@@ -34,16 +34,16 @@ Three variants are available:
   - date
   - dom
   - exif
-  - fpm
+  - cgi-fcgi
   - gd
-  - gearman*^
+  - gearman*
   - iconv
-  - igbinary*
+  - igbinary
   - intl
   - json
   - mbstring
   - mcrypt
-  - memcache*^
+  - memcache*
   - memcached
   - mysqli
   - mysqlnd
@@ -58,14 +58,14 @@ Three variants are available:
   - phar
   - posix
   - rdkafka~
-  - redis~^
+  - redis~
   - shmop
   - SimpleXML
   - sockets
   - sysvmsg
   - sysvsem
   - sysvshm
-  - xdebug~^
+  - xdebug~
   - xml
   - xmlreader
   - xmlwriter

--- a/container/root/tests/php-fpm/alpine.goss.yaml
+++ b/container/root/tests/php-fpm/alpine.goss.yaml
@@ -18,18 +18,13 @@ command:
     exit-status: 0
     stdout: [PHP 7.0]
     stderr: ['!/./']
-  # On Alpine-only, session is not loaded as part of the core, and must be loaded at this time
-  php -n -d extension=session.so -d extension=redis.so -m | grep redis:
-    exit-status: 0
-    stderr: ['!/./']
   php -n -d extension=rdkafka.so -m | grep rdkafka:
     exit-status: 0
     stderr: ['!/./']
-  # Assert librdkafka version
-  apk info librdkafka | grep 0.9.1:
+  # Assert librdkafka version -0.9.*
+  apk info librdkafka | grep "librdkafka-0.9.":
     exit-status: 0
     stderr: ['!/./']
-    stdout: ['0.9.1']
 
 package:
   php7:

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -24,7 +24,108 @@ command:
   php-fpm -v:
     exit-status: 0
     stderr: ['!/./']
-  # Hack: to test and validate by-default disabled extensions [without side effects]
+
+  # Test the standard extensions are enabled
+  php -m | grep -i apcu:
+    exit-status: 0
+  php -m | grep -i calendar:
+    exit-status: 0
+  php -m | grep -i bz2:
+    exit-status: 0
+  php -m | grep -i ctype:
+    exit-status: 0
+  php -m | grep -i curl:
+    exit-status: 0
+  php -m | grep -i date:
+    exit-status: 0
+  php -m | grep -i dom:
+    exit-status: 0
+  php -m | grep -i exif:
+    exit-status: 0
+  # NOTE: extensions only activates running through FPM mode
+  php-fpm -m | grep -i cgi-fcgi:
+    exit-status: 0
+  php -m | grep -i gd:
+    exit-status: 0
+  php -m | grep -i iconv:
+    exit-status: 0
+  php -m | grep -i intl:
+    exit-status: 0
+  php -m | grep -i json:
+    exit-status: 0
+  php -m | grep -i mbstring:
+    exit-status: 0
+  php -m | grep -i mcrypt:
+    exit-status: 0
+  php -m | grep -i memcached:
+    exit-status: 0
+  php -m | grep -i mysqli:
+    exit-status: 0
+  php -m | grep -i mysqlnd:
+    exit-status: 0
+  php -m | grep -i opcache:
+    exit-status: 0
+  php -m | grep -i openssl:
+    exit-status: 0
+  php -m | grep -i pcntl:
+    exit-status: 0
+  php -m | grep -i pdo:
+    exit-status: 0
+  php -m | grep -i pdo_mysql:
+    exit-status: 0
+  php -m | grep -i phar:
+    exit-status: 0
+  php -m | grep -i posix:
+    exit-status: 0
+  php -m | grep -i readline:
+    exit-status: 0
+  php -m | grep -i shmop:
+    exit-status: 0
+  php -m | grep -i simplexml:
+    exit-status: 0
+  php -m | grep -i sockets:
+    exit-status: 0
+  php -m | grep -i sysvmsg:
+    exit-status: 0
+  php -m | grep -i sysvsem:
+    exit-status: 0
+  php -m | grep -i sysvshm:
+    exit-status: 0
+  php -m | grep -i xml:
+    exit-status: 0
+  php -m | grep -i xmlreader:
+    exit-status: 0
+  php -m | grep -i xmlwriter:
+    exit-status: 0
+  php -m | grep -i zip:
+    exit-status: 0
+  php -m | grep -i zlib:
+    exit-status: 0
+
+  # Test that extra extensions are disabled by default
+  php -m | grep newrelic:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep pdo_pgsql:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep pgsql:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep rdkafka:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep redis:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep yaml:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep xdebug:
+    exit-status: 1
+    stderr: ['!/./']
+  # To test and validate by-default disabled extensions [without side effects]
+  # Hack:
   # 1. run php with no ini file (-n)
   # 2. pass ini key-value (-d), enable the single extension to test
   # 3. list the newly loaded php mods (-m)
@@ -42,3 +143,8 @@ command:
   php -n -d extension=rdkafka.so -m | grep rdkafka:
     exit-status: 0
     stderr: ['!/./']
+  # On some variants, session is not loaded as part of the core, and must be loaded at this time
+  php -n -d extension=session.so -d extension=redis.so -m | grep redis:
+    exit-status: 0
+    # On session-default installs, re-loading session causes a warning, ignore
+    # stderr: ['!/./']

--- a/container/root/tests/php-fpm/edge.goss.yaml
+++ b/container/root/tests/php-fpm/edge.goss.yaml
@@ -41,13 +41,33 @@ package:
     installed: true
   php7.1-mbstring:
     installed: true
+  php7.1-mcrypt:
+    installed: true
   php7.1-mysql:
     installed: true
   php7.1-opcache:
     installed: true
+  php7.1-pgsql:
+    installed: true
+  php7.1-readline:
+    installed: true
   php7.1-xml:
     installed: true
   php7.1-zip:
+    installed: true
+  php-apcu:
+    installed: true
+  php-gearman:
+    installed: true
+  php-igbinary:
+    installed: true
+  php-memcache:
+    installed: true
+  php-memcached:
+    installed: true
+  php-msgpack:
+    installed: true
+  php-xdebug:
     installed: true
 
 file:

--- a/container/root/tests/php-fpm/legacy.goss.yaml
+++ b/container/root/tests/php-fpm/legacy.goss.yaml
@@ -18,9 +18,6 @@ command:
     exit-status: 0
     stdout: [PHP 5.6]
     stderr: ['!/./']
-  php -n -d extension=redis.so -m | grep redis:
-    exit-status: 0
-    stderr: ['!/./']
   # Assert librdkafka version
   dpkg -s librdkafka-dev | grep 0.9.1:
     exit-status: 0
@@ -44,13 +41,33 @@ package:
     installed: true
   php5.6-mbstring:
     installed: true
+  php5.6-mcrypt:
+    installed: true
   php5.6-mysql:
     installed: true
   php5.6-opcache:
     installed: true
+  php5.6-pgsql:
+    installed: true
+  php5.6-readline:
+    installed: true
   php5.6-xml:
     installed: true
   php5.6-zip:
+    installed: true
+  php-apcu:
+    installed: true
+  php-gearman:
+    installed: true
+  php-igbinary:
+    installed: true
+  php-memcache:
+    installed: true
+  php-memcached:
+    installed: true
+  php-msgpack:
+    installed: true
+  php-xdebug:
     installed: true
 
 file:

--- a/container/root/tests/php-fpm/ubuntu.goss.yaml
+++ b/container/root/tests/php-fpm/ubuntu.goss.yaml
@@ -18,9 +18,6 @@ command:
     exit-status: 0
     stdout: [PHP 7.0]
     stderr: ['!/./']
-  php -n -d extension=redis.so -m | grep redis:
-    exit-status: 0
-    stderr: ['!/./']
   php -n -d extension=rdkafka.so -m | grep rdkafka:
     exit-status: 0
     stderr: ['!/./']

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,7 +59,7 @@ edge:
   volumes:
    - ./container/root/app:/app
    - ./container/root/tests/php-fpm/base.goss.yaml:/tests/php-fpm/base.goss.yaml
-   - ./container/root/tests/php-fpm/beta.goss.yaml:/tests/php-fpm/beta.goss.yaml
+   - ./container/root/tests/php-fpm/edge.goss.yaml:/tests/php-fpm/edge.goss.yaml
 legacy:
   build: .
   dockerfile: Dockerfile-legacy
@@ -80,4 +80,4 @@ legacy:
   volumes:
    - ./container/root/app:/app
    - ./container/root/tests/php-fpm/base.goss.yaml:/tests/php-fpm/base.goss.yaml
-   - ./container/root/tests/php-fpm/beta.goss.yaml:/tests/php-fpm/legacy.goss.yaml
+   - ./container/root/tests/php-fpm/legacy.goss.yaml:/tests/php-fpm/legacy.goss.yaml


### PR DESCRIPTION
- Added missing tests for all base extensions
- Added missing bz2 extensions to Alpine
- Added recently supported igbinary to Alpine
- Updated redis extension to 3.1.1 across the board