### PR TITLE
Dockerfile: fixing builds with 2.0.0 base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -33,6 +33,7 @@ RUN /bin/bash -e /security_updates.sh && \
         curl \
         wget \
         software-properties-common \
+        locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
     add-apt-repository ppa:git-core/ppa -y && \
@@ -46,6 +47,7 @@ RUN /bin/bash -e /security_updates.sh && \
     apt-get remove --purge -yq \
         patch \
         software-properties-common \
+        locales \
         wget \
     && \
     /bin/bash /clean.sh
@@ -96,7 +98,7 @@ RUN apt-get update -q && \
     pecl install yaml-2.0.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP7-stable version of Redis \
-    pecl install redis-3.1.1 && \
+    pecl install redis-3.1.2 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/Dockerfile-alpine
+++ b/Dockerfile-alpine
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.0-alpine
+FROM behance/docker-nginx:8.0.0-alpine
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.
@@ -133,7 +133,7 @@ RUN apk update && \
     pecl install yaml-2.0.0 && \
     echo ";extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
 
-    pecl install redis-3.1.1 && \
+    pecl install redis-3.1.2 && \
     echo ";extension=redis.so" > $CONF_PHPMODS/redis.ini && \
 
     pecl install msgpack-2.0.2 && \

--- a/Dockerfile-edge
+++ b/Dockerfile-edge
@@ -33,6 +33,7 @@ RUN /bin/bash -e /security_updates.sh && \
         curl \
         wget \
         software-properties-common \
+        locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
     add-apt-repository ppa:git-core/ppa -y && \
@@ -46,6 +47,7 @@ RUN /bin/bash -e /security_updates.sh && \
     apt-get remove --purge -yq \
         patch \
         software-properties-common \
+        locales \
         wget \
     && \
     /bin/bash /clean.sh
@@ -96,7 +98,7 @@ RUN apt-get update -q && \
     pecl install yaml-2.0.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP 7.1-stable version of Redis
-    pecl install redis-3.1.1 && \
+    pecl install redis-3.1.2 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/Dockerfile-legacy
+++ b/Dockerfile-legacy
@@ -33,6 +33,7 @@ RUN /bin/bash -e /security_updates.sh && \
         curl \
         wget \
         software-properties-common \
+        locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
     add-apt-repository ppa:git-core/ppa -y && \
@@ -46,6 +47,7 @@ RUN /bin/bash -e /security_updates.sh && \
     apt-get remove --purge -yq \
         patch \
         software-properties-common \
+        locales \
         wget \
     && \
     /bin/bash /clean.sh
@@ -96,7 +98,7 @@ RUN apt-get update -q && \
     pecl install yaml-1.3.0 && \
     echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP5-stable version of Redis \
-    pecl install redis-3.1.1 && \
+    pecl install redis-3.1.2 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \


### PR DESCRIPTION
- Upgraded Redis to 3.1.2
- Fixed newly missing `locale` from `software-properties-common` package
- Locking Alpine to prevent 7.1 upgrade