### PR TITLE
XDebug: Providing Baseline Defaults and Togglability

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,8 @@ See parent(s) [docker-nginx](https://github.com/behance/docker-nginx), [docker-b
 Variable | Example | Default | Description
 --- | --- | --- | ---
 `*` | `DATABASE_HOST=master.rds.aws.com` | - | PHP has access to environment variables by default
-`CFG_APP_DEBUG` | `CFG_APP_DEBUG=1` | 1 | Set to `1` or `true` will cue the Opcache to watch for file changes. Set to 0 for *production mode*, which provides a sizeable performance boost, though manually updating a file will not be seen unless the opcache is reset.
+`CFG_APP_DEBUG` | `CFG_APP_DEBUG=1` | 1 | Setting to `1` or `true` will cue the Opcache to watch for file changes. Set to 0 for *production mode*, which provides a sizeable performance boost, though manually updating a file will not be seen unless the opcache is reset.
+`CFG_XDEBUG_ENABLE` | `CFG_XDEBUG_ENABLE=1` | - | Setting to `1` or `true` will enable the XDebug extension, which is preconfigured to allow remote debugging as well as profiling. NOTE: Requires "dev" mode be enabled via `CFG_APP_DEBUG`.
 `SERVER_MAX_BODY_SIZE` | `SERVER_MAX_BODY_SIZE=4M` | 1M | Allows the downstream application to specify a non-default `client_max_body_size` configuration for the `server`-level directive in `/etc/nginx/sites-available/default`
 `SERVER_FASTCGI_BUFFERS` | `SERVER_FASTCGI_BUFFERS=‘512 32k’` | 256 16k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)
 `SERVER_FASTCGI_BUFFER_SIZE` | `SERVER_FASTCGI_BUFFER_SIZE=‘256k’` | 128k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers_size), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)

--- a/container/root/etc/php/7.0/mods-available/xdebug.ini
+++ b/container/root/etc/php/7.0/mods-available/xdebug.ini
@@ -1,0 +1,23 @@
+; Enable The Extension
+;zend_extension=xdebug.so
+
+; Remote Debugging
+xdebug.remote_enable=on
+xdebug.remote_handler=dbgp
+xdebug.remote_mode=req
+; xdebug.remote_host=192.168.59.3
+xdebug.remote_connect_back=on
+; This is for EVERY request (if set to 1)
+xdebug.remote_autostart=0
+
+; Nesting level (updated for Behat)
+xdebug.max_nesting_level=256
+
+; Profiling
+xdebug.profiler_output_dir=/app/.cachegrind
+; This is for EVERY request (if set to 1)
+xdebug.profiler_enable=0
+; Otherwise, use this to enable remote trigger via request params
+xdebug.profiler_enable_trigger=1
+xdebug.profiler_enable_trigger_value=
+xdebug.profiler_output_name=docker-php-%u-%R.cachegrind

--- a/container/root/run.d/99-xdebug.sh
+++ b/container/root/run.d/99-xdebug.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [[ ($CFG_APP_DEBUG = 1 || $CFG_APP_DEBUG = '1' || $CFG_APP_DEBUG = 'true') && ($CFG_XDEBUG_ENABLE = 1 || $CFG_XDEBUG_ENABLE = '1' || $CFG_XDEBUG_ENABLE = 'true') ]]
+then
+  echo '[debug] Enabling XDebug extension'
+  sed -i 's/^;zend_extension/zend_extension/' $CONF_PHPMODS/xdebug.ini
+  if [ -x "$(command -v phpenmod)" ]; then
+    phpenmod xdebug
+  fi
+else
+  echo '[debug] XDebug remains disabled'
+fi

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -144,3 +144,6 @@ command:
     exit-status: 0
     # On session-default installs, re-loading session causes a warning, ignore
     # stderr: ['!/./']
+  php -n -d zend_extension=xdebug.so --ri xdebug:
+    exit-status: 0
+    stderr: ['!/./']


### PR DESCRIPTION
@bryanlatten It has been requested now by multiple folks to provide a simpler solution of enabling step debugging across our apps.  This PR aims to enable this only in `dev` mode, and also if the user supplies `CFG_XDEBUG_ENABLE` to a truthy value.  The default values of `xdebug.ini` work with most debugging clients.

cc: @nemtsov @ingluisjimenez @mikeklein13 