### PR TITLE
Dockerfile: added bcmath as an ext

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -65,6 +65,7 @@ RUN apt-get update -q && \
     apt-get -yqq install \
         php5.6 \
         php5.6-apcu \
+        php5.6-bcmath \
         php5.6-bz2 \
         php5.6-curl \
         php5.6-dev \

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -65,6 +65,7 @@ RUN apt-get update -q && \
     apt-get -yqq install \
         php7.0 \
         php7.0-apcu \
+        php7.0-bcmath \
         php7.0-bz2 \
         php7.0-curl \
         php7.0-dev \

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -65,6 +65,7 @@ RUN apt-get update -q && \
     apt-get -yqq install \
         php7.1 \
         php7.1-apcu \
+        php7.1-bcmath \
         php7.1-bz2 \
         php7.1-curl \
         php7.1-dev \

--- a/Dockerfile-71-alpine
+++ b/Dockerfile-71-alpine
@@ -31,6 +31,7 @@ RUN apk update && \
       curl \
       wget \
       php7 \
+      php7-bcmath \
       php7-bz2 \
       php7-fpm \
       php7-apcu \

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -79,6 +79,7 @@ RUN apt-get update -q && \
 
 RUN apt-get -yqq install \
         php7.2 \
+        php7.2-bcmath \
         php7.2-bz2 \
         php7.2-curl \
         php7.2-dev \

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
 #### New naming scheme: `PHP_MAJOR.PHP_MINOR-Major.Minor.Patch(-variant)`
 
 - `PHP_MAJOR.PHP_MINOR` are the runtime versions of PHP. 
-- `Major.Minor.Patch` are versions of the container provisioning software
+- `Major.Minor.Patch` are versions of the container provisioning software 
 - `(-variant)`, an optional distinction, i.e. `-alpine`. Alpine variants are slim versions of the container.
 
 
@@ -28,6 +28,7 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
 `~`  - disabled by default (use `phpenmod` to enable on non-Alpine variants, uncomment .ini file otherwise)
 
   - apcu
+  - bcmath
   - bz2
   - calendar
   - ctype

--- a/container/root/tests/php-fpm/7.2.goss.yaml
+++ b/container/root/tests/php-fpm/7.2.goss.yaml
@@ -29,9 +29,11 @@ command:
   # Test the standard extensions are enabled
   php -m | grep -i apcu:
     exit-status: 0
-  php -m | grep -i calendar:
+  php -m | grep -i bcmath:
     exit-status: 0
   php -m | grep -i bz2:
+    exit-status: 0
+  php -m | grep -i calendar:
     exit-status: 0
   php -m | grep -i ctype:
     exit-status: 0

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -28,9 +28,11 @@ command:
   # Test the standard extensions are enabled
   php -m | grep -i apcu:
     exit-status: 0
-  php -m | grep -i calendar:
+  php -m | grep -i bcmath:
     exit-status: 0
   php -m | grep -i bz2:
+    exit-status: 0
+  php -m | grep -i calendar:
     exit-status: 0
   php -m | grep -i ctype:
     exit-status: 0


### PR DESCRIPTION
Sidenote: in Mac's `brew` formula,` bcmath` is enabled by default