### PR TITLE
Dockerfile: 7.2, added back some missing mods

### DIFF
--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -104,11 +104,26 @@ RUN apt-get -yqq install \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
     # Install new PHP 7.X-stable version of Yaml \
-    # pecl install yaml-2.0.0 && \
-    # echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
+    pecl install yaml-2.0.2 && \
+    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP 7.X-stable version of Redis
-    # pecl install redis-3.1.2 && \
-    # echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
+    pecl install redis-3.1.2 && \
+    echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
+
+    # TODO: use the packaged versions above, don't build from scratch \
+
+    pecl install igbinary-2.0.1 && \
+    echo "extension=igbinary.so" > $CONF_PHPMODS/igbinary.ini && \
+    phpenmod igbinary && \
+
+    pecl install msgpack-2.0.2 && \
+    echo "extension=msgpack.so" > $CONF_PHPMODS/msgpack.ini && \
+    phpenmod msgpack && \
+
+    pecl install apcu-5.1.8 && \
+    echo "extension=apcu.so" > $CONF_PHPMODS/apcu.ini && \
+    phpenmod apcu && \
+
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \
         php7.2-dev \

--- a/README.md
+++ b/README.md
@@ -28,8 +28,8 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
 `~`  - disabled by default (use `phpenmod` to enable on non-Alpine variants, uncomment .ini file otherwise)
 
   - apcu
-  - calendar
   - bz2
+  - calendar
   - ctype
   - curl
   - date
@@ -39,14 +39,14 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
   - gd
   - gearman*^
   - iconv
-  - igbinary^
+  - igbinary
   - intl
   - json
   - mbstring
   - mcrypt^
   - memcache*^
   - memcached^
-  - msgpack^
+  - msgpack
   - mysqli
   - mysqlnd
   - newrelic~^ (activates with env variables)
@@ -59,7 +59,7 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
   - pgsql~
   - phar
   - posix
-  - redis~^
+  - redis~
   - shmop
   - SimpleXML
   - sockets
@@ -71,7 +71,7 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
   - xml
   - xmlreader
   - xmlwriter
-  - yaml~^
+  - yaml~
   - zip
   - zlib
 

--- a/container/root/tests/php-fpm/7.2.goss.yaml
+++ b/container/root/tests/php-fpm/7.2.goss.yaml
@@ -27,8 +27,8 @@ command:
     stderr: ['!/./']
 
   # Test the standard extensions are enabled
-  # php -m | grep -i apcu:
-  #   exit-status: 0
+  php -m | grep -i apcu:
+    exit-status: 0
   php -m | grep -i calendar:
     exit-status: 0
   php -m | grep -i bz2:
@@ -50,6 +50,8 @@ command:
     exit-status: 0
   php -m | grep -i iconv:
     exit-status: 0
+  php -m | grep -i igbinary:
+    exit-status: 0
   php -m | grep -i intl:
     exit-status: 0
   php -m | grep -i json:
@@ -60,6 +62,8 @@ command:
   #   exit-status: 0
   # php -m | grep -i memcached:
   #   exit-status: 0
+  php -m | grep -i msgpack:
+    exit-status: 0
   php -m | grep -i mysqli:
     exit-status: 0
   php -m | grep -i mysqlnd:
@@ -115,12 +119,12 @@ command:
   php -m | grep pgsql:
     exit-status: 1
     stderr: ['!/./']
-  # php -m | grep redis:
-  #   exit-status: 1
-  #   stderr: ['!/./']
-  # php -m | grep yaml:
-  #   exit-status: 1
-  #   stderr: ['!/./']
+  php -m | grep redis:
+    exit-status: 1
+    stderr: ['!/./']
+  php -m | grep yaml:
+    exit-status: 1
+    stderr: ['!/./']
   php -m | grep xdebug:
     exit-status: 1
     stderr: ['!/./']
@@ -130,9 +134,9 @@ command:
   # 2. pass ini key-value (-d), enable the single extension to test
   # 3. list the newly loaded php mods (-m)
   # 4. grep the output of the loaded mods for the one under test
-  # php -n -d extension=yaml.so -m | grep yaml:
-  #   exit-status: 0
-  #   stderr: ['!/./']
+  php -n -d extension=yaml.so -m | grep yaml:
+    exit-status: 0
+    stderr: ['!/./']
   php -n -d extension=pgsql.so -m | grep pgsql:
     exit-status: 0
     stderr: ['!/./']
@@ -141,12 +145,10 @@ command:
     exit-status: 0
     stderr: ['!/./']
   # On some variants, session is not loaded as part of the core, and must be loaded at this time
-  # php -n -d extension=session.so -d extension=redis.so -m | grep redis:
-  #   exit-status: 0
+  php -n -d extension=redis.so -m | grep redis:
+    exit-status: 0
     # On session-default installs, re-loading session causes a warning, ignore
-    # stderr: ['!/./']
-
-
+    stderr: ['!/./']
 
 
 


### PR DESCRIPTION
Now that PECL lib has been updated for 7.2, installing from source is now possible
- msgpack
- igbinary
- redis
- yaml
- apcu