### PR TITLE
Dockerfile: 7.2 package updates, exclusions

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -61,6 +61,9 @@ RUN apt-get update -q && \
             php7.1-cli \
             php7.1-common \
             php7.1-json \
+            php7.2-cli \
+            php7.2-common \
+            php7.2-json \
     && \
     apt-get -yqq install \
         php5.6 \
@@ -83,27 +86,25 @@ RUN apt-get update -q && \
         php5.6-memcached \
         php5.6-xdebug \
         php5.6-xml \
+        php5.6-yaml \
         php5.6-zip \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
-        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
+    phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
     rm -rf /usr/lib/php/20121212 && \
-    # rm -rf /usr/lib/php/20131226 && \
     rm -rf /usr/lib/php/20151012 && \
     rm -rf /usr/lib/php/20160303 && \
+    rm -rf /usr/lib/php/20170718 && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
-    # Install new PHP5-stable version of Yaml
-    pecl install yaml-1.3.0 && \
-    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP5-stable version of Redis \
-    pecl install redis-3.1.2 && \
+    pecl install redis-3.1.3 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -61,6 +61,9 @@ RUN apt-get update -q && \
             php7.1-cli \
             php7.1-common \
             php7.1-json \
+            php7.2-cli \
+            php7.2-common \
+            php7.2-json \
     && \
     apt-get -yqq install \
         php7.0 \
@@ -82,29 +85,27 @@ RUN apt-get update -q && \
         php7.0-memcached \
         php7.0-mysql \
         php7.0-xdebug \
+        php7.0-yaml \
         php7.0-xml \
         php7.0-zip \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
-        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
+    phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
     rm -rf /usr/lib/php/20121212 && \
     rm -rf /usr/lib/php/20131226 && \
-    # rm -rf /usr/lib/php/20151012 && \
     rm -rf /usr/lib/php/20160303 && \
+    rm -rf /usr/lib/php/20170718 && \
 
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
-    # Install new PHP7-stable version of Yaml \
-    pecl install yaml-2.0.0 && \
-    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP7-stable version of Redis \
-    pecl install redis-3.1.2 && \
+    pecl install redis-3.1.3 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -61,6 +61,9 @@ RUN apt-get update -q && \
             php7.0-cli \
             php7.0-common \
             php7.0-json \
+            php7.2-cli \
+            php7.2-common \
+            php7.2-json \
     && \
     apt-get -yqq install \
         php7.1 \
@@ -82,28 +85,26 @@ RUN apt-get update -q && \
         php7.1-memcache \
         php7.1-memcached \
         php7.1-xml \
+        php7.1-yaml \
         php7.1-zip \
         php-xdebug \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
-        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
+    phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
     rm -rf /usr/lib/php/20121212 && \
     rm -rf /usr/lib/php/20131226 && \
     rm -rf /usr/lib/php/20151012 && \
-    # rm -rf /usr/lib/php/20160303 && \
+    rm -rf /usr/lib/php/20170718 && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
-    # Install new PHP 7.1-stable version of Yaml \
-    pecl install yaml-2.0.0 && \
-    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP 7.1-stable version of Redis
-    pecl install redis-3.1.2 && \
+    pecl install redis-3.1.3 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/Dockerfile-71-alpine
+++ b/Dockerfile-71-alpine
@@ -133,10 +133,10 @@ RUN apk update && \
     pecl install igbinary-2.0.1 && \
     echo "extension=igbinary.so" > $CONF_PHPMODS/igbinary.ini && \
 
-    pecl install yaml-2.0.0 && \
+    pecl install yaml-2.0.2 && \
     echo ";extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
 
-    pecl install redis-3.1.2 && \
+    pecl install redis-3.1.3 && \
     echo ";extension=redis.so" > $CONF_PHPMODS/redis.ini && \
 
     pecl install msgpack-2.0.2 && \

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -66,12 +66,7 @@ RUN apt-get update -q && \
             php7.1-json
 
 # TODO: fix these packages:
-# php7.2-igbinary
-# php7.2-apcu
 # php7.2-mcrypt
-# php7.2-gearman
-# php7.2-memcache
-# php7.2-memcached
 # php-xdebug
 # newrelic-php5
 # newrelic-php5-common
@@ -79,20 +74,26 @@ RUN apt-get update -q && \
 
 RUN apt-get -yqq install \
         php7.2 \
+        php7.2-apcu \
         php7.2-bcmath \
         php7.2-bz2 \
         php7.2-curl \
         php7.2-dev \
         php7.2-fpm \
+        php7.2-gearman \
         php7.2-gd \
+        php7.2-igbinary \
         php7.2-intl \
         php7.2-json \
         php7.2-mbstring \
+        php7.2-memcache \
+        php7.2-memcached \
+        php7.2-msgpack \
         php7.2-mysql \
         php7.2-pgsql \
         php7.2-xml \
+        php7.2-yaml \
         php7.2-zip \
-        libyaml-dev \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
@@ -104,26 +105,9 @@ RUN apt-get -yqq install \
     rm -rf /usr/lib/php/20160303 && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
-    # Install new PHP 7.X-stable version of Yaml \
-    pecl install yaml-2.0.2 && \
-    echo "extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
     # Install new PHP 7.X-stable version of Redis
-    pecl install redis-3.1.2 && \
+    pecl install redis-3.1.3 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
-
-    # TODO: use the packaged versions above, don't build from scratch \
-
-    pecl install igbinary-2.0.1 && \
-    echo "extension=igbinary.so" > $CONF_PHPMODS/igbinary.ini && \
-    phpenmod igbinary && \
-
-    pecl install msgpack-2.0.2 && \
-    echo "extension=msgpack.so" > $CONF_PHPMODS/msgpack.ini && \
-    phpenmod msgpack && \
-
-    pecl install apcu-5.1.8 && \
-    echo "extension=apcu.so" > $CONF_PHPMODS/apcu.ini && \
-    phpenmod apcu && \
 
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \

--- a/README.md
+++ b/README.md
@@ -38,15 +38,15 @@ Add’s PHP-FPM, mods, and specific backend configuration to Behance’s [docker
   - exif
   - cgi-fcgi
   - gd
-  - gearman*^
+  - gearman*
   - iconv
   - igbinary
   - intl
   - json
   - mbstring
   - mcrypt^
-  - memcache*^
-  - memcached^
+  - memcache*
+  - memcached
   - msgpack
   - mysqli
   - mysqlnd

--- a/container/root/tests/php-fpm/5.6.goss.yaml
+++ b/container/root/tests/php-fpm/5.6.goss.yaml
@@ -11,13 +11,16 @@ command:
     exit-status: 0
     stdout: [6]
     stderr: ['!/./']
-  php-fpm5.6 -m:
+  php-fpm -m:
     exit-status: 0
     stderr: ['!/./']
-  php-fpm5.6 -v:
+  php-fpm -v:
     exit-status: 0
     stdout: [PHP 5.6]
     stderr: ['!/./']
+  # Not common to all variants, test in supported children
+  php -m | grep -i memcache:
+    exit-status: 0
 
 package:
   php5.6:

--- a/container/root/tests/php-fpm/7.0.goss.yaml
+++ b/container/root/tests/php-fpm/7.0.goss.yaml
@@ -11,13 +11,16 @@ command:
     exit-status: 0
     stdout: [0]
     stderr: ['!/./']
-  php-fpm7.0 -m:
+  php-fpm -m:
     exit-status: 0
     stderr: ['!/./']
-  php-fpm7.0 -v:
+  php-fpm -v:
     exit-status: 0
     stdout: [PHP 7.0]
     stderr: ['!/./']
+  # Not common to all variants, test in supported children
+  php -m | grep -i memcache:
+    exit-status: 0
 
 package:
   php7.0:

--- a/container/root/tests/php-fpm/7.1-alpine.goss.yaml
+++ b/container/root/tests/php-fpm/7.1-alpine.goss.yaml
@@ -11,10 +11,10 @@ command:
     exit-status: 0
     stdout: [1]
     stderr: ['!/./']
-  php-fpm7 -m:
+  php-fpm -m:
     exit-status: 0
     stderr: ['!/./']
-  php-fpm7 -v:
+  php-fpm -v:
     exit-status: 0
     stdout: [PHP 7.1]
     stderr: ['!/./']

--- a/container/root/tests/php-fpm/7.1.goss.yaml
+++ b/container/root/tests/php-fpm/7.1.goss.yaml
@@ -18,6 +18,9 @@ command:
     exit-status: 0
     stdout: [PHP 7.1]
     stderr: ['!/./']
+  # Not common to all variants, test in supported children
+  php -m | grep -i memcache:
+    exit-status: 0
 
 package:
   php7.1:

--- a/container/root/tests/php-fpm/7.2.goss.yaml
+++ b/container/root/tests/php-fpm/7.2.goss.yaml
@@ -50,6 +50,8 @@ command:
     exit-status: 0
   php -m | grep -i gd:
     exit-status: 0
+  php -m | grep -i gearman:
+    exit-status: 0
   php -m | grep -i iconv:
     exit-status: 0
   php -m | grep -i igbinary:
@@ -62,8 +64,11 @@ command:
     exit-status: 0
   # php -m | grep -i mcrypt:
   #   exit-status: 0
-  # php -m | grep -i memcached:
-  #   exit-status: 0
+  # Not common to all variants, test in supported children
+  php -m | grep -i memcache:
+    exit-status: 0
+  php -m | grep -i memcached:
+    exit-status: 0
   php -m | grep -i msgpack:
     exit-status: 0
   php -m | grep -i mysqli:
@@ -164,10 +169,10 @@ command:
     exit-status: 0
     stdout: [2]
     stderr: ['!/./']
-  php-fpm7.2 -m:
+  php-fpm -m:
     exit-status: 0
     stderr: ['!/./']
-  php-fpm7.2 -v:
+  php-fpm -v:
     exit-status: 0
     stdout: [PHP 7.2]
     stderr: ['!/./']
@@ -203,18 +208,18 @@ package:
     installed: true
   php7.2-zip:
     installed: true
-  # php-apcu:
-  #   installed: true
-  # php-gearman:
-  #   installed: true
-  # php-igbinary:
-  #   installed: true
-  # php-memcache:
-  #   installed: true
-  # php-memcached:
-  #   installed: true
-  # php-msgpack:
-  #   installed: true
+  php7.2-apcu:
+    installed: true
+  php7.2-gearman:
+    installed: true
+  php7.2-igbinary:
+    installed: true
+  php7.2-memcache:
+    installed: true
+  php7.2-memcached:
+    installed: true
+  php7.2-msgpack:
+    installed: true
   # php-xdebug:
   #   installed: true
 


### PR DESCRIPTION
- Due to some poorly established PPA dependencies on PHP extension libs, some PHP 7.2 packages may get pulled during non-PHP 7.2 installation. Prevent.
- [PHP 7.2] added missing `memcache`, `memcached`, `gearman` extensions
- [ubuntu] instead of building some extensions from scratch, use newly-aligned packaged versions
- Redis extension: 3.0.2 --> 3.0.3
- [alpine] yaml 2.0.0 --> 2.0.2
- Added missing `memcache` extension test, where supported
- Test commands now aligned around non-versioned entrypoints