### PR TITLE
Dockerfile-72: overnight package name changes

### DIFF
--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -97,6 +97,7 @@ RUN apt-get -yqq install \
     && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
+    phpdismod yaml && \
     # phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
     rm -rf /usr/lib/php/20121212 && \

--- a/container/root/tests/php-fpm/7.2.goss.yaml
+++ b/container/root/tests/php-fpm/7.2.goss.yaml
@@ -208,17 +208,17 @@ package:
     installed: true
   php7.2-zip:
     installed: true
-  php7.2-apcu:
+  php-apcu:
     installed: true
-  php7.2-gearman:
+  php-gearman:
     installed: true
-  php7.2-igbinary:
+  php-igbinary:
     installed: true
-  php7.2-memcache:
+  php-memcache:
     installed: true
-  php7.2-memcached:
+  php-memcached:
     installed: true
-  php7.2-msgpack:
+  php-msgpack:
     installed: true
   # php-xdebug:
   #   installed: true


### PR DESCRIPTION
An upstream package name change is now blocking the 7.2 variant from building. Fixed.