### PR TITLE
Dockerfile: un-break gearman build issue

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -35,7 +35,7 @@ RUN /bin/bash -e /security_updates.sh && \
         locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
-    add-apt-repository ppa:git-core/ppa -y && \
+    add-apt-repository ppa:ondrej/pkg-gearman -y && \
     add-apt-repository ppa:ondrej/php -y && \
     echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list && \
     wget -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
@@ -66,6 +66,7 @@ RUN apt-get update -q && \
             php7.2-json \
     && \
     apt-get -yqq install \
+        libgearman8 \
         php5.6 \
         php5.6-apcu \
         php5.6-bcmath \
@@ -74,6 +75,7 @@ RUN apt-get update -q && \
         php5.6-dev \
         php5.6-fpm \
         php5.6-gd \
+        php5.6-gearman \
         php5.6-igbinary \
         php5.6-intl \
         php5.6-json \
@@ -81,7 +83,6 @@ RUN apt-get update -q && \
         php5.6-mcrypt \
         php5.6-mysql \
         php5.6-pgsql \
-        php5.6-gearman \
         php5.6-memcache \
         php5.6-memcached \
         php5.6-xdebug \

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -35,7 +35,7 @@ RUN /bin/bash -e /security_updates.sh && \
         locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
-    add-apt-repository ppa:git-core/ppa -y && \
+    add-apt-repository ppa:ondrej/pkg-gearman -y && \
     add-apt-repository ppa:ondrej/php -y && \
     echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list && \
     wget -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
@@ -66,6 +66,7 @@ RUN apt-get update -q && \
             php7.2-json \
     && \
     apt-get -yqq install \
+        libgearman8 \
         php7.0 \
         php7.0-apcu \
         php7.0-bcmath \

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -35,7 +35,7 @@ RUN /bin/bash -e /security_updates.sh && \
         locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
-    add-apt-repository ppa:git-core/ppa -y && \
+    add-apt-repository ppa:ondrej/pkg-gearman -y && \
     add-apt-repository ppa:ondrej/php -y && \
     echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list && \
     wget -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
@@ -66,6 +66,7 @@ RUN apt-get update -q && \
             php7.2-json \
     && \
     apt-get -yqq install \
+        libgearman8 \
         php7.1 \
         php7.1-apcu \
         php7.1-bcmath \
@@ -74,6 +75,7 @@ RUN apt-get update -q && \
         php7.1-dev \
         php7.1-fpm \
         php7.1-gd \
+        php7.1-gearman \
         php7.1-igbinary \
         php7.1-intl \
         php7.1-json \
@@ -81,7 +83,6 @@ RUN apt-get update -q && \
         php7.1-mcrypt \
         php7.1-mysql \
         php7.1-pgsql \
-        php7.1-gearman \
         php7.1-memcache \
         php7.1-memcached \
         php7.1-xml \

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -35,7 +35,7 @@ RUN /bin/bash -e /security_updates.sh && \
         locales \
     && \
     locale-gen en_US.UTF-8 && export LANG=en_US.UTF-8 && \
-    add-apt-repository ppa:git-core/ppa -y && \
+    add-apt-repository ppa:ondrej/pkg-gearman -y && \
     add-apt-repository ppa:ondrej/php -y && \
     echo 'deb http://apt.newrelic.com/debian/ newrelic non-free' | tee /etc/apt/sources.list.d/newrelic.list && \
     wget -O- https://download.newrelic.com/548C16BF.gpg | apt-key add - && \
@@ -73,6 +73,7 @@ RUN apt-get update -q && \
 # newrelic-daemon
 
 RUN apt-get -yqq install \
+        libgearman8 \
         php7.2 \
         php7.2-apcu \
         php7.2-bcmath \
@@ -80,8 +81,8 @@ RUN apt-get -yqq install \
         php7.2-curl \
         php7.2-dev \
         php7.2-fpm \
-        php7.2-gearman \
         php7.2-gd \
+        php7.2-gearman \
         php7.2-igbinary \
         php7.2-intl \
         php7.2-json \

--- a/container/root/tests/php-fpm/5.6.goss.yaml
+++ b/container/root/tests/php-fpm/5.6.goss.yaml
@@ -21,6 +21,8 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
+  php -m | grep -i gearman:
+    exit-status: 0
 
 package:
   php5.6:

--- a/container/root/tests/php-fpm/7.0.goss.yaml
+++ b/container/root/tests/php-fpm/7.0.goss.yaml
@@ -21,6 +21,8 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
+  php -m | grep -i gearman:
+    exit-status: 0
 
 package:
   php7.0:

--- a/container/root/tests/php-fpm/7.1.goss.yaml
+++ b/container/root/tests/php-fpm/7.1.goss.yaml
@@ -21,6 +21,8 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
+  php -m | grep -i gearman:
+    exit-status: 0
 
 package:
   php7.1:


### PR DESCRIPTION
- Removed unused git-core PPA
- Added gearman PPA
- Added libgearman8, now required for 2.X.X series extensions
- Added missing runtime extension tests for gearman, not just the package check
- Unbroke the build