### PR TITLE
Dockerfile: removed whitespace, new docker warning

### DIFF
--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -102,7 +102,6 @@ RUN apt-get update -q && \
     rm -rf /usr/lib/php/20131226 && \
     rm -rf /usr/lib/php/20160303 && \
     rm -rf /usr/lib/php/20170718 && \
-
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \
     # Install new PHP7-stable version of Redis \
@@ -112,7 +111,6 @@ RUN apt-get update -q && \
     apt-get remove --purge -yq \
         php7.0-dev \
     && \
-
     /bin/bash /clean.sh
 
 # Overlay the root filesystem from this repo

--- a/Dockerfile-71-alpine
+++ b/Dockerfile-71-alpine
@@ -129,22 +129,16 @@ RUN apk update && \
         autoconf file g++ gcc libc-dev make pkgconf re2c php7-dev php7-pear \
     && \
     sed -i 's/^exec $PHP -C -n/exec $PHP -C/g' $(which pecl) && \
-
     pecl install igbinary-2.0.1 && \
     echo "extension=igbinary.so" > $CONF_PHPMODS/igbinary.ini && \
-
     pecl install yaml-2.0.2 && \
     echo ";extension=yaml.so" > $CONF_PHPMODS/yaml.ini && \
-
     pecl install redis-3.1.3 && \
     echo ";extension=redis.so" > $CONF_PHPMODS/redis.ini && \
-
     pecl install msgpack-2.0.2 && \
     echo "extension=msgpack.so" > $CONF_PHPMODS/msgpack.ini && \
-
     pecl install memcached-3.0.3 && \
     echo "extension=memcached.so" > $CONF_PHPMODS/memcached.ini && \
-
     rm -rf /usr/share/php7 && \
     apk del .phpize_deps && \
     /bin/bash -e /clean.sh

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -110,7 +110,6 @@ RUN apt-get -yqq install \
     # Install new PHP 7.X-stable version of Redis
     pecl install redis-3.1.3 && \
     echo "extension=redis.so" > $CONF_PHPMODS/redis.ini && \
-
     # Remove dev packages that were only in place just to compile extensions
     apt-get remove --purge -yq \
         php7.2-dev \


### PR DESCRIPTION
Newer versions of Docker emit warnings (soon to be errors) when whitespace is detected within `RUN` statements