### PR TITLE
Goss: remove gearman tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 
 env:
-  DOCKER_COMPOSE_VERSION: 1.10.0
+  DOCKER_COMPOSE_VERSION: 1.17.1
 
 services:
   - docker

--- a/container/root/tests/php-fpm/5.6.goss.yaml
+++ b/container/root/tests/php-fpm/5.6.goss.yaml
@@ -21,8 +21,6 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
-  php -m | grep -i gearman:
-    exit-status: 0
 
 package:
   php5.6:
@@ -56,8 +54,6 @@ package:
   php5.6-zip:
     installed: true
   php-apcu:
-    installed: true
-  php-gearman:
     installed: true
   php-igbinary:
     installed: true

--- a/container/root/tests/php-fpm/7.0.goss.yaml
+++ b/container/root/tests/php-fpm/7.0.goss.yaml
@@ -21,8 +21,6 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
-  php -m | grep -i gearman:
-    exit-status: 0
 
 package:
   php7.0:
@@ -56,8 +54,6 @@ package:
   php7.0-zip:
     installed: true
   php-apcu:
-    installed: true
-  php-gearman:
     installed: true
   php-igbinary:
     installed: true

--- a/container/root/tests/php-fpm/7.1.goss.yaml
+++ b/container/root/tests/php-fpm/7.1.goss.yaml
@@ -21,8 +21,6 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
-  php -m | grep -i gearman:
-    exit-status: 0
 
 package:
   php7.1:
@@ -56,8 +54,6 @@ package:
   php7.1-zip:
     installed: true
   php-apcu:
-    installed: true
-  php-gearman:
     installed: true
   php-igbinary:
     installed: true

--- a/container/root/tests/php-fpm/7.2.goss.yaml
+++ b/container/root/tests/php-fpm/7.2.goss.yaml
@@ -50,8 +50,6 @@ command:
     exit-status: 0
   php -m | grep -i gd:
     exit-status: 0
-  php -m | grep -i gearman:
-    exit-status: 0
   php -m | grep -i iconv:
     exit-status: 0
   php -m | grep -i igbinary:
@@ -209,8 +207,6 @@ package:
   php7.2-zip:
     installed: true
   php-apcu:
-    installed: true
-  php-gearman:
     installed: true
   php-igbinary:
     installed: true


### PR DESCRIPTION
Updated travis to block PR's appropriately. The bryanlatten --> behance migration broke this integration