### PR TITLE
Alpine: removing newly broken package check

### DIFF
--- a/container/root/tests/php-fpm/7.1-alpine.goss.yaml
+++ b/container/root/tests/php-fpm/7.1-alpine.goss.yaml
@@ -102,5 +102,3 @@ package:
     installed: true
   php7-zip:
     installed: true
-  php7-zlib:
-    installed: true


### PR DESCRIPTION
zlib is not distributed or required as an independent package anymore. 
It is tested as a required extension in the parent test suite.