### PR TITLE
Remove phpinfo() & replace with simple echo for testing

### DIFF
--- a/container/root/app/public/index.php
+++ b/container/root/app/public/index.php
@@ -7,17 +7,4 @@ $stderr = fopen( "php://stderr", 'w' );
 fwrite( $stdout, 'Using STDOUT pipe for output' );
 fwrite( $stderr, 'Using STDERR pipe for output' );
 
-phpinfo();
-
-// Use the below form to test uploads
-?>
-
-<form method="post" action="/" enctype="multipart/form-data">
-  <p>
-  Please specify a file, or a set of files:<br>
-  <input type="file" name="datafile">
-  </p>
-  <div>
-  <input type="submit" value="Send">
-  </div>
-</form>
+echo "PHP Version " . PHP_VERSION;


### PR DESCRIPTION
By default phpinfo can expose credentials in environment
variables. An unsuspecting developer may accidentally deploy
without replacing this index.php first. Using `echo` is a safer
option.