### PR TITLE
PHP 7.3: supporting native decoration-free logs

### DIFF
--- a/Dockerfile-56
+++ b/Dockerfile-56
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3
+FROM behance/docker-nginx:8.5
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-70
+++ b/Dockerfile-70
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3
+FROM behance/docker-nginx:8.5
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-71
+++ b/Dockerfile-71
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3
+FROM behance/docker-nginx:8.5
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-72
+++ b/Dockerfile-72
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3
+FROM behance/docker-nginx:8.5
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-72-alpine
+++ b/Dockerfile-72-alpine
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3-alpine
+FROM behance/docker-nginx:8.5-alpine
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.3/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_FPM_LOG_LIMIT=4096 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -133,8 +134,15 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     phpenmod overrides && \
     # Enable NewRelic via Ubuntu symlinks, but disable in file. Cross-variant startup script uncomments with env vars.
     phpenmod newrelic && \
-    # - Run standard set of tweaks to ensure runs performant, reliably, and consistent between variants
-    /bin/bash -e /prep-php.sh
+    # Run standard set of tweaks to ensure runs performant, reliably, and consistent between variants
+    /bin/bash -e /prep-php.sh && \
+    # Add new 7.3+ conf
+    sed -i "s/;decorate_workers_output.*/decorate_workers_output = no/" $CONF_FPMPOOL && \
+    sed -i "s/;log_limit.*/log_limit = \${PHP_FPM_LOG_LIMIT}/" $CONF_PHPFPM && \
+    # Experimental, eventually disable to maximize performance in heavy logging scenarios
+    sed -i "s/;log_buffering.*/log_buffering = yes/" $CONF_PHPFPM && \
+    # HACK: simplify the previous <=7.2 command wrapper without streaming sed processors
+    sed -ri "s/(exec php-fpm)(.*)\|.*\|.*/\1\2/" /etc/services-available/php-fpm/.command
 
 RUN goss -g /tests/php-fpm/7.3.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.3
+FROM behance/docker-nginx:8.5
 MAINTAINER Bryan Latten <latten@adobe.com>
 
 # Set TERM to suppress warning messages.
@@ -24,6 +24,7 @@ ENV CONF_PHPFPM=/etc/php/7.3/fpm/php-fpm.conf \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
     PHP_FPM_LOG_LIMIT=4096 \
+    PHP_FPM_LOG_BUFFERING=yes \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -140,9 +141,7 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     sed -i "s/;decorate_workers_output.*/decorate_workers_output = no/" $CONF_FPMPOOL && \
     sed -i "s/;log_limit.*/log_limit = \${PHP_FPM_LOG_LIMIT}/" $CONF_PHPFPM && \
     # Experimental, eventually disable to maximize performance in heavy logging scenarios
-    sed -i "s/;log_buffering.*/log_buffering = yes/" $CONF_PHPFPM && \
-    # HACK: simplify the previous <=7.2 command wrapper without streaming sed processors
-    sed -ri "s/(exec php-fpm)(.*)\|.*\|.*/\1\2/" /etc/services-available/php-fpm/.command
+    sed -i "s/;log_buffering.*/log_buffering = \${PHP_FPM_LOG_BUFFERING}/" $CONF_PHPFPM
 
 RUN goss -g /tests/php-fpm/7.3.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -143,5 +143,8 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     # Experimental, eventually disable to maximize performance in heavy logging scenarios
     sed -i "s/;log_buffering.*/log_buffering = \${PHP_FPM_LOG_BUFFERING}/" $CONF_PHPFPM
 
-RUN goss -g /tests/php-fpm/7.3.goss.yaml validate && \
+# HACK: workaround for https://github.com/aelsabbahy/goss/issues/392
+# Run the child and parent test configs separately
+RUN goss -g /tests/php-fpm/base.goss.yaml validate && \
+    goss -g /tests/php-fpm/7.3.goss.yaml validate && \
     /aufs_hack.sh

--- a/Dockerfile-73
+++ b/Dockerfile-73
@@ -23,8 +23,6 @@ ENV CONF_PHPFPM=/etc/php/7.3/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
-    PHP_FPM_LOG_LIMIT=4096 \
-    PHP_FPM_LOG_BUFFERING=yes \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -138,10 +136,7 @@ RUN cp /etc/php/7.0/mods-available/* $CONF_PHPMODS && \
     # Run standard set of tweaks to ensure runs performant, reliably, and consistent between variants
     /bin/bash -e /prep-php.sh && \
     # Add new 7.3+ conf
-    sed -i "s/;decorate_workers_output.*/decorate_workers_output = no/" $CONF_FPMPOOL && \
-    sed -i "s/;log_limit.*/log_limit = \${PHP_FPM_LOG_LIMIT}/" $CONF_PHPFPM && \
-    # Experimental, eventually disable to maximize performance in heavy logging scenarios
-    sed -i "s/;log_buffering.*/log_buffering = \${PHP_FPM_LOG_BUFFERING}/" $CONF_PHPFPM
+    sed -i "s/;decorate_workers_output.*/decorate_workers_output = no/" $CONF_FPMPOOL
 
 # HACK: workaround for https://github.com/aelsabbahy/goss/issues/392
 # Run the child and parent test configs separately

--- a/README.md
+++ b/README.md
@@ -179,26 +179,28 @@ See parent(s) for additional configuration options:
 
 Variable | Example | Default | Description
 --- | --- | --- | ---
-`*` | `DATABASE_HOST=master.rds.aws.com` | - | PHP has access to environment variables by default
-`CFG_APP_DEBUG` | `CFG_APP_DEBUG=1` | 1 | Setting to `1` or `true` will cue the Opcache to watch for file changes. Set to 0 for *production mode*, which provides a sizeable performance boost, though manually updating a file will not be seen unless the opcache is reset.
-`CFG_XDEBUG_ENABLE` | `CFG_XDEBUG_ENABLE=1` | - | Setting to `1` or `true` will enable the XDebug extension, which is preconfigured to allow remote debugging as well as profiling. NOTE: Requires "dev" mode be enabled via `CFG_APP_DEBUG`.
-`SERVER_MAX_BODY_SIZE` | `SERVER_MAX_BODY_SIZE=4M` | 1M | Allows the downstream application to specify a non-default `client_max_body_size` configuration for the `server`-level directive in `/etc/nginx/sites-available/default`
-`SERVER_FASTCGI_BUFFERS` | `SERVER_FASTCGI_BUFFERS=‘512 32k’` | 256 16k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)
-`SERVER_FASTCGI_BUFFER_SIZE` | `SERVER_FASTCGI_BUFFER_SIZE=‘256k’` | 128k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers_size), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)
-`SERVER_FASTCGI_BUSY_BUFFERS_SIZE` | `SERVER_FASTCGI_BUSY_BUFFERS_SIZE=‘1024k’` | 256k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_busy_buffers_size)
-`REPLACE_NEWRELIC_APP` | `REPLACE_NEWRELIC_APP=prod-server-abc` | - | Sets application name for newrelic
-`REPLACE_NEWRELIC_LICENSE` | `REPLACE_NEWRELIC_LICENSE=abcdefg` | - | Sets license for newrelic, when combined with above, will enable newrelic reporting
-`NEWRELIC_TRACING_ENABLED` | `NEWRELIC_TRACING_ENABLED=true` | disabled | Sets transaction_tracer and distributed_tracing true for newrelic, when combined with above, will enable [newrelic distributed tracing](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-configuration#inivar-distributed-enabled)
-`PHP_FPM_MEMORY_LIMIT` | `PHP_FPM_MEMORY_LIMIT=256M` | 192MB | Sets memory limit for FPM instances of PHP
-`PHP_FPM_MAX_EXECUTION_TIME` | `PHP_FPM_MAX_EXECUTION_TIME=30` | 60 | Sets time limit for FPM workers
-`PHP_FPM_UPLOAD_MAX_FILESIZE` | `PHP_FPM_UPLOAD_MAX_FILESIZE=100M` | 1M | Sets both upload_max_filesize and post_max_size
-`PHP_FPM_MAX_CHILDREN` | `PHP_FPM_MAX_CHILDREN=15` | 4096 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
-`PHP_FPM_START_SERVERS` | `PHP_FPM_START_SERVERS=40` | 20 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
-`PHP_FPM_MAX_REQUESTS` | `PHP_FPM_MAX_REQUESTS=100` | 1024 | [docs](http://php.net/manual/en/install.fpm.configuration.php) How many requests an individual FPM worker will process before recycling
-`PHP_FPM_MIN_SPARE_SERVERS` | `PHP_FPM_MIN_SPARE_SERVERS=10` | 5 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
-`PHP_OPCACHE_MEMORY_CONSUMPTION` | `PHP_OPCACHE_MEMORY_CONSUMPTION=512` | 128 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.memory-consumption)
-`PHP_OPCACHE_MAX_WASTED_PERCENTAGE` | `PHP_OPCACHE_MAX_WASTED_PERCENTAGE=10` | 5 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.max-wasted-percentage)
-`PHP_OPCACHE_INTERNED_STRINGS_BUFFER` | `PHP_OPCACHE_INTERNED_STRINGS_BUFFER=64` | 16 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.interned-strings-buffer)
+(all) | DATABASE_HOST=master.rds.aws.com | - | PHP has access to environment variables by default
+CFG_APP_DEBUG | CFG_APP_DEBUG=1 | 1 | Setting to `1` or `true` will cue the Opcache to watch for file changes. Set to 0 for *production mode*, which provides a sizeable performance boost, though manually updating a file will not be seen unless the opcache is reset.
+CFG_XDEBUG_ENABLE | CFG_XDEBUG_ENABLE=1 | - | Setting to `1` or `true` will enable the XDebug extension, which is preconfigured to allow remote debugging as well as profiling. NOTE: Requires "dev" mode be enabled via `CFG_APP_DEBUG`.
+SERVER_MAX_BODY_SIZE | SERVER_MAX_BODY_SIZE=4M | 1M | Allows the downstream application to specify a non-default `client_max_body_size` configuration for the `server`-level directive in `/etc/nginx/sites-available/default`
+SERVER_FASTCGI_BUFFERS | SERVER_FASTCGI_BUFFERS='512 32k' | 256 16k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)
+SERVER_FASTCGI_BUFFER_SIZE | SERVER_FASTCGI_BUFFER_SIZE='256k' | 128k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_buffers_size), [tweaking](https://gist.github.com/magnetikonline/11312172#determine-actual-fastcgi-response-sizes)
+SERVER_FASTCGI_BUSY_BUFFERS_SIZE | SERVER_FASTCGI_BUSY_BUFFERS_SIZE='1024k' | 256k | [docs](http://nginx.org/en/docs/http/ngx_http_fastcgi_module.html#fastcgi_busy_buffers_size)
+REPLACE_NEWRELIC_APP | REPLACE_NEWRELIC_APP=prod-server-abc | - | Sets application name for newrelic
+REPLACE_NEWRELIC_LICENSE | REPLACE_NEWRELIC_LICENSE=abcdefg | - | Sets license for newrelic, when combined with above, will enable newrelic reporting
+NEWRELIC_TRACING_ENABLED | NEWRELIC_TRACING_ENABLED=true | disabled | Sets transaction_tracer and distributed_tracing true for newrelic, when combined with above, will enable [newrelic distributed tracing](https://docs.newrelic.com/docs/agents/php-agent/configuration/php-agent-configuration#inivar-distributed-enabled)
+PHP_FPM_MEMORY_LIMIT | PHP_FPM_MEMORY_LIMIT=256M | 192MB | Sets memory limit for FPM instances of PHP
+PHP_FPM_MAX_EXECUTION_TIME | PHP_FPM_MAX_EXECUTION_TIME=30 | 60 | Sets time limit for FPM workers
+PHP_FPM_UPLOAD_MAX_FILESIZE | PHP_FPM_UPLOAD_MAX_FILESIZE=100M | 1M | Sets both upload_max_filesize and post_max_size
+PHP_FPM_MAX_CHILDREN | PHP_FPM_MAX_CHILDREN=15 | 4096 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
+PHP_FPM_START_SERVERS | PHP_FPM_START_SERVERS=40 | 20 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
+PHP_FPM_MAX_REQUESTS | PHP_FPM_MAX_REQUESTS=100 | 1024 | [docs](http://php.net/manual/en/install.fpm.configuration.php) How many requests an individual FPM worker will process before recycling
+PHP_FPM_MIN_SPARE_SERVERS | PHP_FPM_MIN_SPARE_SERVERS=10 | 5 | [docs](http://php.net/manual/en/install.fpm.configuration.php)
+PHP_OPCACHE_MEMORY_CONSUMPTION | PHP_OPCACHE_MEMORY_CONSUMPTION=512 | 128 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.memory-consumption)
+PHP_OPCACHE_MAX_WASTED_PERCENTAGE | PHP_OPCACHE_MAX_WASTED_PERCENTAGE=10 | 5 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.max-wasted-percentage)
+PHP_OPCACHE_INTERNED_STRINGS_BUFFER | PHP_OPCACHE_INTERNED_STRINGS_BUFFER=64 | 16 | [docs](http://php.net/manual/en/opcache.configuration.php#ini.opcache.interned-strings-buffer)
+PHP_FPM_LOG_LIMIT | PHP_FPM_LOG_LIMIT=4096 | 1024 | PHP 7.3-only, allows configurable stdout message max length [docs](https://www.php.net/manual/en/install.fpm.configuration.php)
+PHP_FPM_LOG_BUFFERING | PHP_FPM_LOG_BUFFERING=no | yes | Experimental, PHP 7.3-only [docs](https://www.php.net/manual/en/install.fpm.configuration.php)
 
 ### Testing
 ---

--- a/container/root/etc/cont-finish.d/01-fpm.sh
+++ b/container/root/etc/cont-finish.d/01-fpm.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+
+# To produce an orderly stop, drain connections from the reverse proxy.
+# Once the proxy has no active connections, plug can be pulled,
+# as there are no more active connections.
+
+echo "[finish php-fpm] starting graceful shutdown"
+
+NGINX_ACTIVE=`pgrep nginx | wc -w`
+
+if [ $NGINX_ACTIVE -ne 0 ]; then
+  echo "[finish php-fpm] waiting for nginx to terminate"
+  # wait $NGINX_PID; <-- does not work since not a child process
+  # @see https://stackoverflow.com/questions/8048628/wait-child-process-but-get-error-pid-is-not-a-child-of-this-shell
+  while [ `pgrep nginx | wc -w` -ne 0 ]; do sleep .10; done
+  echo "[finish php-fpm] nginx terminated"
+fi
+
+echo "[finish php-fpm] shutting down"
+
+# TODO: bypass FPM's clunky ungraceful shutdown, which breaks stdout and outputs ugly warnings
+# @see https://stackoverflow.com/questions/36564074/nginx-php-fpm-graceful-stop-sigquit-not-so-graceful
+# pkill -QUIT -o php-fpm
+

--- a/container/root/etc/cont-init.d/20-fpm-validation.sh
+++ b/container/root/etc/cont-init.d/20-fpm-validation.sh
@@ -1,8 +1,9 @@
-#!/bin/bash
+#!/usr/bin/with-contenv bash
 
 # Validate that env config overrides are acceptable to php-fpm
 php-fpm -t &> /dev/null
 
-if [ $? == 1 ]; then
+if [ $? != 0 ]; then
+  echo "[fpm-validation] Config validation failed, cannot start..."
   php-fpm -t
 fi

--- a/container/root/etc/cont-init.d/20-fpm-validation.sh
+++ b/container/root/etc/cont-init.d/20-fpm-validation.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+# Validate that env config overrides are acceptable to php-fpm
+php-fpm -t &> /dev/null
+
+if [ $? == 1 ]; then
+  php-fpm -t
+fi

--- a/container/root/etc/services-available/php-fpm/.command
+++ b/container/root/etc/services-available/php-fpm/.command
@@ -4,11 +4,12 @@
 set -o pipefail
 
 # IMPORTANT: PHP 7.3+ optionally allows undecorated stdout/stderr, removing pipe magic requirement
-grep "decorate_workers_output = no" $CONF_FPMPOOL
+UPGRADE_COMMAND=`grep "decorate_workers_output = no" $CONF_FPMPOOL`
 
-if [ $? ]; then
+if [ $UPGRADE_COMMAND ]; then
   exec php-fpm -F -O
-fi
 else
   exec php-fpm -F -O 2>&1 | sed -u 's,.*: \"\(.*\)$,\1,'| sed -u 's,\"$,,'
 fi
+
+

--- a/container/root/etc/services-available/php-fpm/.command
+++ b/container/root/etc/services-available/php-fpm/.command
@@ -3,4 +3,12 @@
 # Ensures that a failure of php-fpm doesn't return with a 0, even if the right-hand side does
 set -o pipefail
 
-exec php-fpm -F -O 2>&1 | sed -u 's,.*: \"\(.*\)$,\1,'| sed -u 's,\"$,,'
+# IMPORTANT: PHP 7.3+ optionally allows undecorated stdout/stderr, removing pipe magic requirement
+grep "decorate_workers_output = no" $CONF_FPMPOOL
+
+if [ $? ]; then
+  exec php-fpm -F -O
+fi
+else
+  exec php-fpm -F -O 2>&1 | sed -u 's,.*: \"\(.*\)$,\1,'| sed -u 's,\"$,,'
+fi

--- a/container/root/etc/services-available/php-fpm/finish
+++ b/container/root/etc/services-available/php-fpm/finish
@@ -4,5 +4,7 @@
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
+# Suppress superfluous time-of-check-time-of-use (TOCTOU) message
+# @see https://github.com/just-containers/s6-overlay/issues/193
 redirfd -w 2 /dev/null s6-svscanctl -t /var/run/s6/services
 

--- a/container/root/etc/services-available/php-fpm/finish
+++ b/container/root/etc/services-available/php-fpm/finish
@@ -4,4 +4,5 @@
 if { s6-test ${1} -ne 0 }
 if { s6-test ${1} -ne 256 }
 
-s6-svscanctl -t /var/run/s6/services
+redirfd -w 2 /dev/null s6-svscanctl -t /var/run/s6/services
+

--- a/container/root/etc/services-available/php-fpm/run
+++ b/container/root/etc/services-available/php-fpm/run
@@ -8,22 +8,11 @@ trap
 {
   term
   {
-    foreground
-    {
-      backtick -i -n NGINXPID { cat /tmp/.nginx/nginx.pid }
-    }
-    import -u NGINXPID ifthenelse { $NGINXPID }
-    {
-      foreground
-      {
-        echo [sigterm-phpfpm] waiting for nginx to exit
-      }
-      wait { $NGINXPID } import -u ! kill -s SIGQUIT ${!}
-    }
-    foreground
-    {
-      import -u ! kill -s SIGQUIT ${!}
-    }
+    echo [run php-fpm] TERM received
+  }
+  hup
+  {
+    echo [run php-fpm] HUP received
   }
 }
 

--- a/container/root/run.d/11-php-logging.sh
+++ b/container/root/run.d/11-php-logging.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+if [[ $PHP_FPM_LOG_LIMIT ]]
+then
+  echo "[php-fpm] setting log_limit ${PHP_FPM_LOG_LIMIT} (PHP 7.3+ only)"
+  sed -i "s/;log_limit.*/log_limit = ${PHP_FPM_LOG_LIMIT}/" $CONF_PHPFPM
+fi
+
+if [[ $PHP_FPM_LOG_BUFFERING ]]
+then
+  # Experimental, eventually disable to maximize performance in heavy logging scenarios
+  echo "[php-fpm] setting log_buffering ${PHP_FPM_LOG_BUFFERING} (PHP 7.3+ only)"
+  sed -i "s/;log_buffering.*/log_buffering = ${PHP_FPM_LOG_BUFFERING}/" $CONF_PHPFPM
+fi

--- a/container/root/tests/php-fpm/7.3.goss.yaml
+++ b/container/root/tests/php-fpm/7.3.goss.yaml
@@ -15,3 +15,12 @@ command:
   # Not common to all variants, test in supported children
   php -m | grep -i memcache:
     exit-status: 0
+
+file:
+  {{ .Env.CONF_PHPFPM }}:
+    contains:
+      - '/^log_limit = \${PHP_FPM_LOG_LIMIT}/'
+      - '/^log_buffering = yes/'
+  {{ .Env.CONF_FPMPOOL }}:
+    contains:
+      - '/^decorate_workers_output = no/'

--- a/container/root/tests/php-fpm/7.3.goss.yaml
+++ b/container/root/tests/php-fpm/7.3.goss.yaml
@@ -23,11 +23,6 @@ command:
 
 # Using workaround commands until https://github.com/aelsabbahy/goss/issues/392 is solved
 file:
-  {{ .Env.CONF_PHPFPM }}:
-    exists: true
-    contains:
-      - '/log_limit = \${PHP_FPM_LOG_LIMIT}/'
-      - '/log_buffering = \${PHP_FPM_LOG_BUFFERING}/'
   {{ .Env.CONF_FPMPOOL }}:
     exists: true
     contains:

--- a/container/root/tests/php-fpm/7.3.goss.yaml
+++ b/container/root/tests/php-fpm/7.3.goss.yaml
@@ -18,9 +18,11 @@ command:
 
 file:
   {{ .Env.CONF_PHPFPM }}:
+    exists: true
     contains:
-      - '/^log_limit = \${PHP_FPM_LOG_LIMIT}/'
-      - '/^log_buffering = yes/'
+      - '/log_limit = \${PHP_FPM_LOG_LIMIT}/'
+      - '/log_buffering = \${PHP_FPM_LOG_BUFFERING}/'
   {{ .Env.CONF_FPMPOOL }}:
+    exists: true
     contains:
       - '/^decorate_workers_output = no/'

--- a/container/root/tests/php-fpm/7.3.goss.yaml
+++ b/container/root/tests/php-fpm/7.3.goss.yaml
@@ -1,5 +1,10 @@
-gossfile:
-  base.goss.yaml: {}
+
+# Extended file tests will be overridden/ignored from parent
+# Note: Other variants may not include extended file tests, are not susceptible
+# @see https://github.com/aelsabbahy/goss/issues/392
+
+# gossfile:
+#   base.goss.yaml: {}
 
 command:
   # IMPORTANT: confirm the major/minor version of PHP itself
@@ -16,6 +21,7 @@ command:
   php -m | grep -i memcache:
     exit-status: 0
 
+# Using workaround commands until https://github.com/aelsabbahy/goss/issues/392 is solved
 file:
   {{ .Env.CONF_PHPFPM }}:
     exists: true

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -24,6 +24,9 @@ command:
   php-fpm -v:
     exit-status: 0
     stderr: ['!/./']
+  php-fpm -t:
+    exit-status: 0
+    stderr: ['/successful/']
 
   # Test the standard extensions are enabled
   php -m | grep -i apcu:


### PR DESCRIPTION
- [x] Depends on https://github.com/behance/docker-nginx/pull/67
- [x] workaround for goss YAML deep merge on `file` test directive
- Forks startup behavior based on 7.3 + new `ini` directive or not
- Improves shutdown behavior. 
- Added inline startup check for fpm syntax. Prevents bad env variable inputs from producing invalid config
