### PR TITLE
add exception for files living under .well-known

### DIFF
--- a/container/root/etc/nginx/sites-available/default
+++ b/container/root/etc/nginx/sites-available/default
@@ -65,8 +65,9 @@ server {
     deny all;
   }
 
-  # Protect against accessing hidden files
-  location ~ /\. {
+  # Protect against accessing hidden files, except for files living under .well-known
+  # @see https://www.ietf.org/rfc/rfc5785.txt
+  location ~ /\.(?!well-known/) {
     access_log off;
     log_not_found off;
     deny all;


### PR DESCRIPTION
.well-known is a common place to put metadata files that other companies need to pull without polluting root: https://www.ietf.org/rfc/rfc5785.txt. An example is the `apple-app-site-association` to make Universal Links work: https://developer.apple.com/library/archive/documentation/General/Conceptual/AppSearch/UniversalLinks.html

Adding an exception to .well-known for the . file rule