### PR TITLE
Base: updated to 8.8

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7
+FROM behance/docker-nginx:8.8
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.0/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20151012 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -56,6 +57,11 @@ COPY container/root/usr/local/bin/pecl-install /usr/local/bin
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
+            manpages \
+            manpages-dev \
+            apache2 \
+            apache2-bin \
+            libapache2-mod-php7.0 \
             php5.6-cli \
             php5.6-common \
             php5.6-json \
@@ -80,15 +86,12 @@ RUN apt-get update -q && \
         php7.0-curl \
         php7.0-fpm \
         php7.0-gd \
-        php7.0-igbinary \
         php7.0-intl \
         php7.0-json \
         php7.0-mbstring \
         php7.0-mcrypt \
         php7.0-memcache \
-        php7.0-memcached \
         php7.0-pgsql \
-        php7.0-redis \
         php7.0-xdebug \
         php7.0-xml \
         php7.0-yaml \
@@ -98,21 +101,40 @@ RUN apt-get update -q && \
         newrelic-daemon \
         # Order of operations issue is preventing this from being installed in alphabetical order
         php7.0-mysql \
+        # below required to compile non-packaged extensions
+        php7.0-dev \
+        pkg-config \
+        libmemcached-dev \
+        pkg-config \
+        zlib1g-dev \
     && \
+    pecl-install \
+        igbinary \
+        memcached \
+        msgpack \
+        redis \
+    && \
+    apt-get remove --purge -yq \
+        php7.0-dev \
+        pkg-config \
+        build-essential \
+        cpp \
+        cpp-7 \
+        gcc \
+    && \
+    /bin/bash /clean.sh \
+    && \
+    phpenmod memcached && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
-    rm -rf /usr/lib/php/20121212 && \
-    rm -rf /usr/lib/php/20131226 && \
-    rm -rf /usr/lib/php/20160303 && \
-    rm -rf /usr/lib/php/20170718 && \
-    rm -rf /usr/lib/php/20180731 && \
-    rm -rf /usr/lib/php/20190902 && \
+    cd /usr/lib/php && \
+    ls -d */ | grep '[0-9]\{8\}' | grep -v ${PHP_ENGINE_VERSION} | xargs rm -rf && \
     # Remove unused agents for other PHP versions
-    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-20151012.so | xargs rm && \
+    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-${PHP_ENGINE_VERSION}.so | xargs rm && \
     cd / && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7
+FROM behance/docker-nginx:8.8
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.1/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20160303 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -56,6 +57,11 @@ COPY container/root/usr/local/bin/pecl-install /usr/local/bin
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.0 don't accidentally get added by PPA
     apt-mark hold \
+            manpages \
+            manpages-dev \
+            apache2 \
+            apache2-bin \
+            libapache2-mod-php7.1 \
             php5.6-cli \
             php5.6-common \
             php5.6-json \
@@ -80,17 +86,13 @@ RUN apt-get update -q && \
         php7.1-curl \
         php7.1-fpm \
         php7.1-gd \
-        php7.1-igbinary \
         php7.1-intl \
         php7.1-json \
         php7.1-mbstring \
         php7.1-memcache \
-        php7.1-memcached \
-        php7.1-msgpack \
         php7.1-mcrypt \
         php7.1-mysql \
         php7.1-pgsql \
-        php7.1-redis \
         php7.1-xdebug \
         php7.1-xml \
         php7.1-yaml \
@@ -99,21 +101,40 @@ RUN apt-get update -q && \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
+        # below required to compile non-packaged extensions
+        php7.1-dev \
+        pkg-config \
+        libmemcached-dev \
+        pkg-config \
+        zlib1g-dev \
     && \
+    pecl-install \
+        igbinary \
+        memcached \
+        msgpack \
+        redis \
+    && \
+    apt-get remove --purge -yq \
+        php7.1-dev \
+        pkg-config \
+        build-essential \
+        cpp \
+        cpp-7 \
+        gcc \
+    && \
+    /bin/bash /clean.sh \
+    && \
+    phpenmod memcached && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
-    rm -rf /usr/lib/php/20121212 && \
-    rm -rf /usr/lib/php/20131226 && \
-    rm -rf /usr/lib/php/20151012 && \
-    rm -rf /usr/lib/php/20170718 && \
-    rm -rf /usr/lib/php/20180731 && \
-    rm -rf /usr/lib/php/20190902 && \
+    cd /usr/lib/php && \
+    ls -d */ | grep '[0-9]\{8\}' | grep -v ${PHP_ENGINE_VERSION} | xargs rm -rf && \
     # Remove unused agents for other PHP versions
-    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-20160303.so | xargs rm && \
+    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-${PHP_ENGINE_VERSION}.so | xargs rm && \
     cd / && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7
+FROM behance/docker-nginx:8.8
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.2/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20170718 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -56,6 +57,11 @@ COPY container/root/usr/local/bin/pecl-install /usr/local/bin
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
+            manpages \
+            manpages-dev \
+            apache2 \
+            apache2-bin \
+            libapache2-mod-php7.2 \
             php5.6-cli \
             php5.6-common \
             php5.6-json \
@@ -80,16 +86,12 @@ RUN apt-get update -q && \
         php7.2-curl \
         php7.2-fpm \
         php7.2-gd \
-        php7.2-igbinary \
         php7.2-intl \
         php7.2-json \
         php7.2-mbstring \
         php7.2-memcache \
-        php7.2-memcached \
-        php7.2-msgpack \
         php7.2-mysql \
         php7.2-pgsql \
-        php7.2-redis \
         php7.2-xdebug \
         php7.2-xml \
         php7.2-yaml \
@@ -97,21 +99,40 @@ RUN apt-get update -q && \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
+        # below required to compile non-packaged extensions
+        php7.2-dev \
+        pkg-config \
+        libmemcached-dev \
+        pkg-config \
+        zlib1g-dev \
     && \
+    pecl-install \
+        igbinary \
+        memcached \
+        msgpack \
+        redis \
+    && \
+    apt-get remove --purge -yq \
+        php7.2-dev \
+        pkg-config \
+        build-essential \
+        cpp \
+        cpp-7 \
+        gcc \
+    && \
+    /bin/bash /clean.sh \
+    && \
+    phpenmod memcached && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
-    rm -rf /usr/lib/php/20121212 && \
-    rm -rf /usr/lib/php/20131226 && \
-    rm -rf /usr/lib/php/20151012 && \
-    rm -rf /usr/lib/php/20160303 && \
-    rm -rf /usr/lib/php/20180731 && \
-    rm -rf /usr/lib/php/20190902 && \
+    cd /usr/lib/php && \
+    ls -d */ | grep '[0-9]\{8\}' | grep -v ${PHP_ENGINE_VERSION} | xargs rm -rf && \
     # Remove unused agents for other PHP versions
-    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-20170718.so | xargs rm && \
+    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-${PHP_ENGINE_VERSION}.so | xargs rm && \
     cd / && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7
+FROM behance/docker-nginx:8.8
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.3/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20180731 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -56,6 +57,11 @@ COPY container/root/usr/local/bin/pecl-install /usr/local/bin
 RUN apt-get update -q && \
     # Ensure PHP 5.5 + 5.6 + 7.1 don't accidentally get added by PPA
     apt-mark hold \
+            manpages \
+            manpages-dev \
+            apache2 \
+            apache2-bin \
+            libapache2-mod-php7.3 \
             php5.6-cli \
             php5.6-common \
             php5.6-json \
@@ -80,16 +86,12 @@ RUN apt-get update -q && \
         php7.3-curl \
         php7.3-fpm \
         php7.3-gd \
-        php7.3-igbinary \
         php7.3-intl \
         php7.3-json \
         php7.3-mbstring \
         php7.3-memcache \
-        php7.3-memcached \
-        php7.3-msgpack \
         php7.3-mysql \
         php7.3-pgsql \
-        php7.3-redis \
         php7.3-xdebug \
         php7.3-xml \
         php7.3-yaml \
@@ -97,21 +99,40 @@ RUN apt-get update -q && \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
+        # below required to compile non-packaged extensions
+        php7.3-dev \
+        pkg-config \
+        libmemcached-dev \
+        pkg-config \
+        zlib1g-dev \
     && \
+    pecl-install \
+        igbinary \
+        memcached \
+        msgpack \
+        redis \
+    && \
+    apt-get remove --purge -yq \
+        php7.3-dev \
+        pkg-config \
+        build-essential \
+        cpp \
+        cpp-7 \
+        gcc \
+    && \
+    /bin/bash /clean.sh \
+    && \
+    phpenmod memcached && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
-    rm -rf /usr/lib/php/20121212 && \
-    rm -rf /usr/lib/php/20131226 && \
-    rm -rf /usr/lib/php/20151012 && \
-    rm -rf /usr/lib/php/20160303 && \
-    rm -rf /usr/lib/php/20170718 && \
-    rm -rf /usr/lib/php/20190902 && \
+    cd /usr/lib/php && \
+    ls -d */ | grep '[0-9]\{8\}' | grep -v ${PHP_ENGINE_VERSION} | xargs rm -rf && \
     # Remove unused agents for other PHP versions
-    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-20180731.so | xargs rm && \
+    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-${PHP_ENGINE_VERSION}.so | xargs rm && \
     cd / && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \

--- a/Dockerfile-7.3-alpine
+++ b/Dockerfile-7.3-alpine
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7-alpine
+FROM behance/docker-nginx:8.8-alpine
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php7/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20180731 \
     CFG_APP_DEBUG=1
 
 RUN apk update && \
@@ -96,8 +97,8 @@ RUN NEWRELIC_MUSL_PATH=$(curl -s https://download.newrelic.com/php_agent/release
     NEWRELIC_DIRECTORY=/root/$(basename $(find . -maxdepth 1 -type d -name newrelic\*)) && \
     cd $NEWRELIC_DIRECTORY && \
     echo "\n" | ./newrelic-install install && \
-    chown root:root $NEWRELIC_DIRECTORY/agent/x64/newrelic-20160303.so && \
-    mv $NEWRELIC_DIRECTORY/agent/x64/newrelic-20180731.so /usr/lib/php7/modules/newrelic.so && \
+    chown root:root $NEWRELIC_DIRECTORY/agent/x64/newrelic-${PHP_ENGINE_VERSION}.so && \
+    mv $NEWRELIC_DIRECTORY/agent/x64/newrelic-${PHP_ENGINE_VERSION}.so /usr/lib/php7/modules/newrelic.so && \
     rm -rf $NEWRELIC_DIRECTORY/agent/x64 && \
     # Fix permissions on extracted folder \
     chown -R $NOT_ROOT_USER:$NOT_ROOT_USER * && \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -1,4 +1,4 @@
-FROM behance/docker-nginx:8.7
+FROM behance/docker-nginx:8.8
 LABEL maintainers="Behance Team <dev-behance@adobe.com>"
 
 # Set TERM to suppress warning messages.
@@ -23,6 +23,7 @@ ENV CONF_PHPFPM=/etc/php/7.4/fpm/php-fpm.conf \
     PHP_OPCACHE_MEMORY_CONSUMPTION=128 \
     PHP_OPCACHE_INTERNED_STRINGS_BUFFER=16 \
     PHP_OPCACHE_MAX_WASTED_PERCENTAGE=5 \
+    PHP_ENGINE_VERSION=20190902 \
     CFG_APP_DEBUG=1
 
 # - Update security packages, only
@@ -56,6 +57,8 @@ COPY container/root/usr/local/bin/pecl-install /usr/local/bin
 RUN apt-get update -q && \
     # Ensure old versions of PHP don't accidentally get added by PPA maintainers
     apt-mark hold \
+            manpages \
+            manpages-dev \
             apache2 \
             apache2-bin \
             libapache2-mod-php7.4 \
@@ -83,16 +86,12 @@ RUN apt-get update -q && \
         php7.4-curl \
         php7.4-fpm \
         php7.4-gd \
-        php7.4-igbinary \
         php7.4-intl \
         php7.4-json \
         php7.4-mbstring \
         php7.4-memcache \
-        php7.4-memcached \
-        php7.4-msgpack \
         php7.4-mysql \
         php7.4-pgsql \
-        php7.4-redis \
         php7.4-xdebug \
         php7.4-xml \
         php7.4-yaml \
@@ -100,22 +99,41 @@ RUN apt-get update -q && \
         newrelic-php5 \
         newrelic-php5-common \
         newrelic-daemon \
+        # below required to compile non-packaged extensions
+        php7.4-dev \
+        pkg-config \
+        libmemcached-dev \
+        pkg-config \
+        zlib1g-dev \
     && \
+    pecl-install \
+        igbinary \
+        memcached \
+        msgpack \
+        redis \
+    && \
+    apt-get remove --purge -yq \
+        php7.4-dev \
+        pkg-config \
+        build-essential \
+        cpp \
+        cpp-7 \
+        gcc \
+    && \
+    /bin/bash /clean.sh \
+    && \
+    phpenmod memcached && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \
     phpdismod yaml && \
     phpdismod xdebug && \
     # Remove extra extensions installed via packages for other versions of PHP, leaving the active engine folder
-    rm -rf /usr/lib/php/20121212 && \
-    rm -rf /usr/lib/php/20131226 && \
-    rm -rf /usr/lib/php/20151012 && \
-    rm -rf /usr/lib/php/20160303 && \
-    rm -rf /usr/lib/php/20170718 && \
-    rm -rf /usr/lib/php/20180731 && \
+    cd /usr/lib/php && \
+    ls -d */ | grep '[0-9]\{8\}' | grep -v ${PHP_ENGINE_VERSION} | xargs rm -rf && \
     rm -rf /usr/lib/php/7.3 && \
     # Remove unused agents for other PHP versions
-    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-20190902.so | xargs rm && \
+    cd /usr/lib/newrelic-php5/agent/x64 && ls | grep -v newrelic-${PHP_ENGINE_VERSION}.so | xargs rm && \
     cd / && \
     curl -sS https://getcomposer.org/installer | php && \
     mv composer.phar /usr/local/bin/composer && \


### PR DESCRIPTION
- Converted flaky packages fully to PECL-only installs
- Added engine ENV variable to DRY up some hacks
- Locking against more leaking packages