### PR TITLE
Fixing missing deps for igbinary and msgpack

### DIFF
--- a/Dockerfile-7.0
+++ b/Dockerfile-7.0
@@ -125,6 +125,8 @@ RUN apt-get update -q && \
     /bin/bash /clean.sh \
     && \
     phpenmod memcached && \
+    phpenmod igbinary && \
+    phpenmod msgpack && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \

--- a/Dockerfile-7.1
+++ b/Dockerfile-7.1
@@ -125,6 +125,8 @@ RUN apt-get update -q && \
     /bin/bash /clean.sh \
     && \
     phpenmod memcached && \
+    phpenmod igbinary && \
+    phpenmod msgpack && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \

--- a/Dockerfile-7.2
+++ b/Dockerfile-7.2
@@ -123,6 +123,8 @@ RUN apt-get update -q && \
     /bin/bash /clean.sh \
     && \
     phpenmod memcached && \
+    phpenmod igbinary && \
+    phpenmod msgpack && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \

--- a/Dockerfile-7.3
+++ b/Dockerfile-7.3
@@ -123,6 +123,8 @@ RUN apt-get update -q && \
     /bin/bash /clean.sh \
     && \
     phpenmod memcached && \
+    phpenmod igbinary && \
+    phpenmod msgpack && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \

--- a/Dockerfile-7.4
+++ b/Dockerfile-7.4
@@ -123,6 +123,8 @@ RUN apt-get update -q && \
     /bin/bash /clean.sh \
     && \
     phpenmod memcached && \
+    phpenmod igbinary && \
+    phpenmod msgpack && \
     phpdismod pdo_pgsql && \
     phpdismod pgsql && \
     phpdismod redis && \

--- a/container/root/tests/php-fpm/base.goss.yaml
+++ b/container/root/tests/php-fpm/base.goss.yaml
@@ -109,6 +109,10 @@ command:
     exit-status: 0
   php -m | grep -i zlib:
     exit-status: 0
+  php -m | grep -i msgpack:
+    exit-status: 0
+  php -m | grep -i igbinary:
+    exit-status: 0
 
   # Test that extra extensions are disabled by default
   php -m | grep newrelic:


### PR DESCRIPTION
Due to last set of changes on https://github.com/behance/docker-php/pull/176 with the Ubuntu 20.04 upgrade, these extensions were no longer enabled by default. 