### PR TITLE
Aligning Env Var Existence Checks in New Relic Startup

### DIFF
--- a/container/root/run.d/07-newrelic.sh
+++ b/container/root/run.d/07-newrelic.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 # When both App ID and license are provided, automatically enable extension
-if [ $REPLACE_NEWRELIC_APP ] && [ $REPLACE_NEWRELIC_LICENSE ]
+if [[ $REPLACE_NEWRELIC_APP ]] && [[ $REPLACE_NEWRELIC_LICENSE ]]
 then
   echo "[newrelic] enabling APM metrics for ${REPLACE_NEWRELIC_APP}"
   sed -i 's/;extension\s\?=/extension =/' $CONF_PHPMODS/newrelic.ini


### PR DESCRIPTION
While instrumenting an application with New Relic for the first time, I was attempting to enable NR locally to ensure the agent and daemon were working correctly and that NR would ingest some test data into a new account.  However, in so doing, I encountered this error during container startup:

```
api_1             | [init] executing /run.d/07-newrelic.sh
api_1             | /run.d/07-newrelic.sh: line 4: [: API: binary operator expected
```

Changing the startup script as per this PR resolved the issue, and also aligned the existence checks with other existence check styles in this directory.  I am not aware of any downside to this approach.